### PR TITLE
Supporting creating router by http method and path

### DIFF
--- a/Sources/HTTPRoute.swift
+++ b/Sources/HTTPRoute.swift
@@ -38,8 +38,16 @@ public struct HTTPRoute {
 
     public init(_ string: String) {
         let comps = Self.components(for: string)
-        self.method = Component(comps.method)
-        self.path = comps.path
+        self.init(method: comps.method, path: comps.path)
+    }
+
+    public init(method: HTTPMethod, path: String) {
+        self.init(method: method.rawValue, path: path)
+    }
+
+    init(method: String, path: String) {
+        self.method = Component(method)
+        self.path = path
             .split(separator: "/", omittingEmptySubsequences: true)
             .map { Component(String($0)) }
     }
@@ -118,4 +126,11 @@ public extension HTTPRoute {
         route.patternMatch(method: request.method.rawValue, path: request.path)
     }
 
+}
+
+extension HTTPRoute: ExpressibleByStringLiteral {
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
 }

--- a/Sources/HTTPServer.swift
+++ b/Sources/HTTPServer.swift
@@ -43,12 +43,12 @@ public final actor HTTPServer {
         self.handlers = []
     }
 
-    public func appendHandler(for route: String, handler: HTTPHandler) {
-        handlers.append((HTTPRoute(route), handler))
+    public func appendHandler(for route: HTTPRoute, handler: HTTPHandler) {
+        handlers.append((route, handler))
     }
 
-    public func appendHandler(for route: String, closure: @escaping (HTTPRequest) async throws -> HTTPResponse) {
-        handlers.append((HTTPRoute(route), ClosureHTTPHandler(closure)))
+    public func appendHandler(for route: HTTPRoute, closure: @escaping (HTTPRequest) async throws -> HTTPResponse) {
+        handlers.append((route, ClosureHTTPHandler(closure)))
     }
 
     public func start() async throws {


### PR DESCRIPTION
Add a little trick by using `ExpressibleByStringLiteral`.

This still allows the usage:
```
await server.appendHandler(for: "GET /mock", handler: .file(named: "mock.json"))
```
and also enable:
```
await server.appendHandler(for: Router(method: .GET, path: "/mock"), handler: .file(named: "mock.json"))
```