### PR TITLE
Simplify code to make URLSession api backward compatible

### DIFF
--- a/Sources/HTTPHandler.swift
+++ b/Sources/HTTPHandler.swift
@@ -76,8 +76,8 @@ public struct ProxyHTTPHandler: HTTPHandler {
 
     public func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
         let req = try makeURLRequest(for: request)
-        let (data, response) = try await session.makeRequest(req)
-        return makeResponse(for: response, data: data)
+        let (data, response) = try await session.data(for: req)
+        return makeResponse(for: response as! HTTPURLResponse, data: data)
     }
 
     func makeURLRequest(for request: HTTPRequest) throws -> URLRequest {

--- a/Sources/URLSession+Async.swift
+++ b/Sources/URLSession+Async.swift
@@ -31,35 +31,42 @@
 
 import Foundation
 
-@available(iOS, deprecated: 15.0, message: "This method should only be called on iOS below 15.0")
-public extension URLSession {
+@available(iOS, deprecated: 15.0, message: "use data(for request: URLRequest) directly")
+@available(macOS, deprecated: 12.0, message: "use data(for request: URLRequest) directly")
+extension URLSession {
 
-  func data(from url: URL) async throws -> (Data, URLResponse) {
-    try await data(for: URLRequest(url: url))
-  }
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
 
-  func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-    var dataTask: URLSessionDataTask?
-    let onCancel = { dataTask?.cancel() }
-
-    return try await withTaskCancellationHandler(
-      operation: {
-        try await withCheckedThrowingContinuation { continuation in
-          dataTask = self.dataTask(with: request) { data, response, error in
-            guard let data = data, let response = response else {
-              let error = error ?? URLError(.unknown)
-              return continuation.resume(throwing: error)
-            }
-
-            continuation.resume(returning: (data, response))
-          }
-
-          dataTask?.resume()
+        if #available(macOS 12.0, iOS 15.0, *) {
+            return try await data(for: request, delegate: nil)
+        } else {
+            return try await makeData(for: request)
         }
-      },
-      onCancel: {
-        onCancel()
-      }
-    )
-  }
+    }
+
+    private func makeData(for request: URLRequest) async throws -> (Data, URLResponse) {
+
+        var dataTask: URLSessionDataTask?
+        let onCancel = { dataTask?.cancel() }
+
+        return try await withTaskCancellationHandler(
+            operation: {
+                try await withCheckedThrowingContinuation { continuation in
+                    dataTask = self.dataTask(with: request) { data, response, error in
+                        guard let data = data, let response = response else {
+                            let error = error ?? URLError(.unknown)
+                            return continuation.resume(throwing: error)
+                        }
+
+                        continuation.resume(returning: (data, response))
+                    }
+
+                    dataTask?.resume()
+                }
+            },
+            onCancel: {
+                onCancel()
+            }
+        )
+    }
 }

--- a/Sources/URLSession+Async.swift
+++ b/Sources/URLSession+Async.swift
@@ -31,41 +31,35 @@
 
 import Foundation
 
-extension URLSession {
+@available(iOS, deprecated: 15.0, message: "This method should only be called on iOS below 15.0")
+public extension URLSession {
 
-    func makeRequest(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-        if #available(macOS 12.0, iOS 15.0, *) {
-            return try await data(for: request) as! (Data, HTTPURLResponse)
-        } else {
-            let continuation = Continuation()
-            return try await withTaskCancellationHandler(
-                operation: { try await continuation.data(for: request, using: self) },
-                onCancel: continuation.cancel
-            )
-        }
-    }
+  func data(from url: URL) async throws -> (Data, URLResponse) {
+    try await data(for: URLRequest(url: url))
+  }
 
-    private final class Continuation {
+  func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+    var dataTask: URLSessionDataTask?
+    let onCancel = { dataTask?.cancel() }
 
-        private var dataTask: URLSessionDataTask?
-        private var continuation: CheckedContinuation<(Data, HTTPURLResponse), Error>?
-
-        func data(for request: URLRequest, using session: URLSession) async throws -> (Data, HTTPURLResponse) {
-            try await withCheckedThrowingContinuation { continuation in
-                self.dataTask = session.dataTask(with: request) { data, response, error in
-                    if let response = response as? HTTPURLResponse {
-                        continuation.resume(returning:  (data ?? Data(), response))
-                    } else {
-                        continuation.resume(throwing: error ?? URLError(.unknown))
-                    }
-                }
-                self.dataTask?.resume()
+    return try await withTaskCancellationHandler(
+      operation: {
+        try await withCheckedThrowingContinuation { continuation in
+          dataTask = self.dataTask(with: request) { data, response, error in
+            guard let data = data, let response = response else {
+              let error = error ?? URLError(.unknown)
+              return continuation.resume(throwing: error)
             }
-        }
 
-        @Sendable
-        func cancel() {
-            dataTask?.cancel()
+            continuation.resume(returning: (data, response))
+          }
+
+          dataTask?.resume()
         }
-    }
+      },
+      onCancel: {
+        onCancel()
+      }
+    )
+  }
 }


### PR DESCRIPTION
This PR creates a backward compatible async func in `URLSession` extension with the same signature to the function in iOS 15. So that making it simpler to clean up code in future.

The code is inspired and borrowed from here: https://www.swiftbysundell.com/articles/making-async-system-apis-backward-compatible/