### PR TITLE
Including QueryItems within Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,27 @@ route ~= HTTPRequest(method: .GET, path: "/hello/dog/world") // true
 route ~= HTTPRequest(method: .POST, path: "/hello/fish/deep/blue/sea") // true
 ```
 
+Specific query items can be matched:
+
+```swift
+let route = HTTPRoute("/hello?time=morning")
+
+route ~= HTTPRequest(method: .GET, path: "/hello?time=morning") // true
+route ~= HTTPRequest(method: .GET, path: "/hello?count=one&time=morning") // true
+route ~= HTTPRequest(method: .GET, path: "/hello") // false
+route ~= HTTPRequest(method: .GET, path: "/hello?time=afternoon") // false
+```
+
+Query item values can include wildcards:
+
+```swift
+let route = HTTPRoute("/hello?time=*")
+
+route ~= HTTPRequest(method: .GET, path: "/hello?time=morning") // true
+route ~= HTTPRequest(method: .GET, path: "/hello?time=afternoon") // true
+route ~= HTTPRequest(method: .GET, path: "/hello") // false
+```
+
 ## AsyncSocket / PollingSocketPool
 
 Internally, FlyingFox uses standard BSD sockets configured with the flag `O_NONBLOCK`. When data is unavailable for a socket (`EWOULDBLOCK`) the task is suspended using the current `AsyncSocketPool` until data is available:

--- a/Tests/HTTPRouteTests.swift
+++ b/Tests/HTTPRouteTests.swift
@@ -235,7 +235,7 @@ final class HTTPRouteTests: XCTestCase {
         )
     }
 
-    func testWildcardPathWithQueryIte_MatchesRoute() {
+    func testWildcardPathWithQueryItem_MatchesRoute() {
         let route = HTTPRoute("/mock/*?fish=*")
 
         XCTAssertTrue(

--- a/Tests/HTTPRouteTests.swift
+++ b/Tests/HTTPRouteTests.swift
@@ -233,6 +233,12 @@ final class HTTPRouteTests: XCTestCase {
                                       query: [.init(name: "cat", value: "dog"),
                                               .init(name: "fish", value: "squid")])
         )
+        
+         XCTAssertFalse(
+             route ~= HTTPRequest.make(method: .GET,
+                                       path: "/mock",
+                                       query: [.init(name: "cat", value: "dog")])
+         )
     }
 
     func testWildcardPathWithQueryItem_MatchesRoute() {

--- a/Tests/HTTPRouteTests.swift
+++ b/Tests/HTTPRouteTests.swift
@@ -174,12 +174,32 @@ final class HTTPRouteTests: XCTestCase {
     }
 
     func testMultipleQueryItems_MatchesRoute() {
-        let route = HTTPRoute("GET /mock?fish=squid&cats=dogs")
+        let route = HTTPRoute("GET /mock?fish=chips&cats=dogs")
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "fish", value: "chips"),
+                                              .init(name: "cats", value: "dogs")])
+        )
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "cats", value: "dogs"),
+                                              .init(name: "fish", value: "chips")])
+        )
 
         XCTAssertFalse(
             route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
                                       query: [.init(name: "fish", value: "chips")])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "cats", value: "dogs")])
         )
 
         XCTAssertFalse(

--- a/Tests/HTTPRouteTests.swift
+++ b/Tests/HTTPRouteTests.swift
@@ -147,4 +147,92 @@ final class HTTPRouteTests: XCTestCase {
                                       path: "/mock/fish")
         )
     }
+
+    func testQueryItem_MatchesRoute() {
+        let route = HTTPRoute("GET /mock?fish=chips")
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "fish", value: "chips")])
+        )
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "cat", value: "dog"),
+                                              .init(name: "fish", value: "squid"),
+                                              .init(name: "fish", value: "chips")])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "cat", value: "dog"),
+                                              .init(name: "fish", value: "squid")])
+        )
+    }
+
+    func testMultipleQueryItems_MatchesRoute() {
+        let route = HTTPRoute("GET /mock?fish=squid&cats=dogs")
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "fish", value: "chips")])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "cat", value: "dog"),
+                                              .init(name: "fish", value: "squid")])
+        )
+    }
+
+    func testQueryItemWildcard_MatchesRoute() {
+        let route = HTTPRoute("GET /mock?fish=*")
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "fish", value: "chips")])
+        )
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "cat", value: "dog"),
+                                              .init(name: "fish", value: "squid"),
+                                              .init(name: "fish", value: "chips")])
+        )
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      query: [.init(name: "cat", value: "dog"),
+                                              .init(name: "fish", value: "squid")])
+        )
+    }
+
+    func testWildcardPathWithQueryIte_MatchesRoute() {
+        let route = HTTPRoute("/mock/*?fish=*")
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock/anemone",
+                                      query: [.init(name: "fish", value: "chips")])
+        )
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .POST,
+                                      path: "/mock/crabs",
+                                      query: [.init(name: "fish", value: "shrimp")])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock/anemone")
+        )
+    }
 }


### PR DESCRIPTION
Adds the ability for routes to pattern match against the query items of `HTTPRequest`.
This allows for handlers to be added for more specific routes;

```swift
await server.appendRoute("GET /meal?side=fish", to: .file(named: "meal-fish.json"))
await server.appendRoute("GET /meal?side=chips", to: .file(named: "meal-chips.json"))
```

`HTTPRoute.QueryItem` is similar to `HTTPRequest.QueryItem` except that the routes value can be a wildcard component with the same matching semantics as the path components.

Because HTTP query parameters can be repeated, the route matches if the specific query item exists at least once.

`GET /meal?side=chips&side=peas&side=chips`

