### PR TITLE
HTTPHeaders within Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,25 @@ route ~= HTTPRequest(method: .GET, path: "/hello?time=afternoon") // true
 route ~= HTTPRequest(method: .GET, path: "/hello") // false
 ```
 
+HTTP headers can be matched:
+
+```swift
+let route = HTTPRoute("*", headers: [.contentType: "application/json"])
+
+route ~= HTTPRequest(headers: [.contentType: "application/json"]) // true
+route ~= HTTPRequest(headers: [.contentType: "application/xml"]) // false
+```
+
+Header values can be wildcards:
+
+```swift
+let route = HTTPRoute("*", headers: [.authorization: "*"])
+
+route ~= HTTPRequest(headers: [.authorization: "abc"]) // true
+route ~= HTTPRequest(headers: [.authorization: "xyz"]) // true
+route ~= HTTPRequest(headers: [:]) // false
+```
+
 ## AsyncSocket / PollingSocketPool
 
 Internally, FlyingFox uses standard BSD sockets configured with the flag `O_NONBLOCK`. When data is unavailable for a socket (`EWOULDBLOCK`) the task is suspended using the current `AsyncSocketPool` until data is available:

--- a/Sources/HTTPHeader.swift
+++ b/Sources/HTTPHeader.swift
@@ -50,6 +50,7 @@ public struct HTTPHeader: Sendable, RawRepresentable, Hashable {
 }
 
 public extension HTTPHeader {
+    static let authorization   = HTTPHeader("Authorization")
     static let connection      = HTTPHeader("Connection")
     static let contentLength   = HTTPHeader("Content-Length")
     static let contentType     = HTTPHeader("Content-Type")

--- a/Tests/HTTPRouteTests.swift
+++ b/Tests/HTTPRouteTests.swift
@@ -261,6 +261,89 @@ final class HTTPRouteTests: XCTestCase {
                                       path: "/mock/anemone")
         )
     }
+
+    func testHeader_MatchesRoute() {
+        let route = HTTPRoute("GET /mock", headers: [.contentType: "json"])
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.contentType: "json"])
+        )
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.contentEncoding: "xml",
+                                                .contentType: "json"])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.contentType: "xml"])
+        )
+    }
+
+    func testMultipleHeaders_MatchesRoute() {
+        let route = HTTPRoute("GET /mock", headers: [.host: "fish",
+                                                     .contentType: "json"])
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.host: "fish",
+                                                .contentType: "json"])
+        )
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.contentType: "json",
+                                                .host: "fish"])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.host: "fish"])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.contentType: "json"])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.contentType: "xml",
+                                                .host: "fish"])
+        )
+    }
+
+    func testHeaderWildcard_MatchesRoute() {
+        let route = HTTPRoute("GET /mock", headers: [.authorization: "*"])
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.authorization: "Bearer abc"])
+        )
+
+        XCTAssertTrue(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.authorization: "Bearer xyz"])
+        )
+
+        XCTAssertFalse(
+            route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
+                                      headers: [.contentType: "xml"])
+        )
+    }
 }
 
 extension HTTPRouteTests {


### PR DESCRIPTION
Adds the ability for routes to pattern match against the headers of `HTTPRequest`.
This allows for handlers to be added for more specific routes;

```swift
let json = HTTPRoute("*", headers: [.contentType: "application/json"])
let xml  = HTTPRoute("*", headers: [.contentType: "application/xml"])

await server.appendRoute(json, to: .file(named: "sample.json"))
await server.appendRoute(xml, to: .file(named: "sample.xml"))
```

Header values can be wildcards routing requests when the header exists;

```swift
let auth = HTTPRoute("*", headers: [.authorization: "*"])

await server.appendRoute(auth, to: .file(named: "authenticated.html"))
await server.appendRoute("*", to: .file(named: "guest.html"))
```
