### PR TITLE
Added extra levels of log messages: debug, warning and critical.

### DIFF
--- a/Sources/HTTPLogging+OSLog.swift
+++ b/Sources/HTTPLogging+OSLog.swift
@@ -41,13 +41,26 @@ public struct OSLogHTTPLogging: HTTPLogging {
         self.logger = logger
     }
 
+    public func logDebug(_ debug: String) {
+        logger.debug("\(debug, privacy: .public)")
+    }
+        
     public func logInfo(_ info: String) {
         logger.info("\(info, privacy: .public)")
+    }
+
+    public func logWarning(_ warning: String) {
+        logger.warning("\(warning, privacy: .public)")
     }
 
     public func logError(_ error: String) {
         logger.error("\(error, privacy: .public)")
     }
+    
+    public func logCritical(_ critical: String) {
+        logger.critical("\(critical, privacy: .public)")
+    }
+
 }
 
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, *)

--- a/Sources/HTTPLogging.swift
+++ b/Sources/HTTPLogging.swift
@@ -30,8 +30,11 @@
 //
 
 public protocol HTTPLogging {
+    func logDebug(_ debug: String)
     func logInfo(_ info: String)
+    func logWarning(_ warning: String)
     func logError(_ error: String)
+    func logCritical(_ critical: String)
 }
 
 public struct PrintHTTPLogger: HTTPLogging {
@@ -42,12 +45,24 @@ public struct PrintHTTPLogger: HTTPLogging {
         self.category = category
     }
 
+    public func logDebug(_ debug: String) {
+        Swift.print("[\(category)] debug: \(debug)")
+    }
+    
     public func logInfo(_ info: String) {
         Swift.print("[\(category)] info: \(info)")
     }
 
+    public func logWarning(_ warning: String) {
+        Swift.print("[\(category)] warning: \(warning)")
+    }
+    
     public func logError(_ error: String) {
         Swift.print("[\(category)] error: \(error)")
+    }
+    
+    public func logCritical(_ critical: String) {
+        Swift.print("[\(category)] critical: \(critical)")
     }
 }
 

--- a/Sources/HTTPServer.swift
+++ b/Sources/HTTPServer.swift
@@ -79,7 +79,7 @@ public final actor HTTPServer {
         do {
             try await start(on: socket)
         } catch {
-            logger?.logError("server error: \(error.localizedDescription)")
+            logger?.logCritical("server error: \(error.localizedDescription)")
             try? socket.close()
             throw error
         }

--- a/Tests/HTTPLogging+OSLogTests.swift
+++ b/Tests/HTTPLogging+OSLogTests.swift
@@ -1,8 +1,8 @@
 //
-//  HTTPLoggingTests.swift
+//  HTTPLogging+OSLogTests.swift
 //  FlyingFox
 //
-//  Created by Simon Whitty on 23/02/2022.
+//  Created by Andre Jacobs on 06/03/2022.
 //  Copyright © 2022 Simon Whitty. All rights reserved.
 //
 //  Distributed under the permissive MIT license
@@ -28,35 +28,19 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-
+#if canImport(OSLog)
 @testable import FlyingFox
 import Foundation
+import OSLog
 import XCTest
 
-final class HTTPLoggingTests: XCTestCase {
-
-    func testPrintLogger_DefaultCategory() {
-        let logger = PrintHTTPLogger.print()
-
-        XCTAssertEqual(
-            logger.category,
-            "FlyingFox"
-        )
-    }
-
-    func testPrintLogger_SetsCategory() {
-        let logger = PrintHTTPLogger.print(category: "Fish")
-
-        XCTAssertEqual(
-            logger.category,
-            "Fish"
-        )
-    }
+final class HTTPLoggingOSLogTests: XCTestCase {
     
-    func testPrintLogger_output() {
-        // NOTE: For now this test is only used to verify the output by manual confirmation
-        // until Swift.print can be unit-tested or we are able to inject a mock.
-        let logger = PrintHTTPLogger.print()
+    func testInfo() {
+        // NOTE: For now this test is only used to verify the output by manual confirmation (e.g. Console.app or log tool)
+        // Run log tool in the terminal first and then run this unit-test:
+        // log stream --level debug --predicate 'category == "FlyingFox"'
+        let logger = OSLogHTTPLogging.oslog()
         
         logger.logDebug("alpha")
         logger.logInfo("bravo")
@@ -65,3 +49,5 @@ final class HTTPLoggingTests: XCTestCase {
         logger.logCritical("echo")
     }
 }
+
+#endif // canImport(OSLog)


### PR DESCRIPTION
I thought it would be useful to add extra levels of logging.
Modified the server.start's logError to be a Critical level since the server will be stopped.

Below is a screenshot showing the output from the unit-test that uses oslog and being captured using the `log` tool.
<img width="812" alt="image" src="https://user-images.githubusercontent.com/1173603/156934599-178b427d-ca78-489c-bd01-c5e0dbd6aa96.png">
