### PR TITLE
Adds Support for AF_UNIX sockets

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/FlyingFox.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FlyingFox.xcscheme
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FlyingFoxTests"
-               BuildableName = "FlyingFoxTests"
-               BlueprintName = "FlyingFoxTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Sources/HTTPConnection.swift
+++ b/Sources/HTTPConnection.swift
@@ -38,8 +38,7 @@ struct HTTPConnection {
 
     init(socket: AsyncSocket) {
         self.socket = socket
-        let remotePeer = try? socket.socket.remotePeer()
-        self.hostname = remotePeer?.host ?? "<unknown>"
+        self.hostname = HTTPConnection.makeIdentifer(from: try? socket.socket.remotePeer())
     }
 
     // some AsyncSequence<HTTPRequest>
@@ -81,6 +80,23 @@ struct HTTPRequestSequence<S: ChunkedAsyncSequence>: AsyncSequence, AsyncIterato
             return nil
         } catch {
             throw error
+        }
+    }
+}
+
+extension HTTPConnection {
+
+    static func makeIdentifer(from peer: Socket.Address?) -> String {
+        guard let peer = peer else {
+            return "<unknown>"
+        }
+        switch peer {
+        case .ip4(let address, port: _):
+            return address
+        case .ip6(let address, port: _):
+            return address
+        case .unix(let path):
+            return path
         }
     }
 }

--- a/Sources/Socket/Socket+Darwin.swift
+++ b/Sources/Socket/Socket+Darwin.swift
@@ -98,6 +98,10 @@ extension Socket {
         Darwin.getpeername(fd, addr, len)
     }
 
+    static func getsockname(_ fd: Int32, _ addr: UnsafeMutablePointer<sockaddr>!, _ len: UnsafeMutablePointer<socklen_t>!) -> Int32 {
+        Darwin.getsockname(fd, addr, len)
+    }
+
     static func inet_ntop(_ domain: Int32, _ addr: UnsafeRawPointer!,
                           _ buffer: UnsafeMutablePointer<CChar>!, _ addrLen: socklen_t) throws {
         if Darwin.inet_ntop(domain, addr, buffer, addrLen) == nil {

--- a/Sources/Socket/Socket+Glibc.swift
+++ b/Sources/Socket/Socket+Glibc.swift
@@ -35,6 +35,38 @@ import Glibc
 extension Socket {
 
     static let stream = Int32(SOCK_STREAM.rawValue)
+    static let in_addr_any = Glibc.in_addr(s_addr: Glibc.in_addr_t(0))
+
+    static func makeAddressINET(port: UInt16) -> Glibc.sockaddr_in {
+        Glibc.sockaddr_in(
+            sin_family: sa_family_t(AF_INET),
+            sin_port: port.bigEndian,
+            sin_addr: in_addr_any,
+            sin_zero: (0, 0, 0, 0, 0, 0, 0, 0)
+        )
+    }
+
+    static func makeAddressINET6(port: UInt16) -> Glibc.sockaddr_in6 {
+        Glibc.sockaddr_in6(
+            sin6_family: sa_family_t(AF_INET6),
+            sin6_port: port.bigEndian,
+            sin6_flowinfo: 0,
+            sin6_addr: in6addr_any,
+            sin6_scope_id: 0
+        )
+    }
+
+    static func makeAddressUnix(path: String) -> Glibc.sockaddr_un {
+        var addr = Glibc.sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let len = UInt8(MemoryLayout<UInt8>.size + MemoryLayout<sa_family_t>.size + path.utf8.count + 1)
+        _ = withUnsafeMutablePointer(to: &addr.sun_path.0) { ptr in
+            path.withCString {
+                strncpy(ptr, $0, Int(len))
+            }
+        }
+        return addr
+    }
 
     static func socket(_ domain: Int32, _ type: Int32, _ protocol: Int32) -> Int32 {
         Glibc.socket(domain, type, `protocol`)
@@ -58,21 +90,9 @@ extension Socket {
         Glibc.getsockopt(fd, level, name, value, len)
     }
 
-    static func sockaddr_in6(port: UInt16) -> sockaddr_in6 {
-        Glibc.sockaddr_in6(
-            sin6_family: sa_family_t(AF_INET6),
-            sin6_port: port.bigEndian,
-            sin6_flowinfo: 0,
-            sin6_addr: in6addr_any,
-            sin6_scope_id: 0
-        )
-    }
-
     static func getpeername(_ fd: Int32, _ addr: UnsafeMutablePointer<sockaddr>!, _ len: UnsafeMutablePointer<socklen_t>!) -> Int32 {
         Glibc.getpeername(fd, addr, len)
     }
-
-    static let sockaddr_in6 = Glibc.sockaddr_in6.self
 
     static func inet_ntop(_ domain: Int32, _ addr: UnsafeRawPointer!,
                           _ buffer: UnsafeMutablePointer<CChar>!, _ addrLen: socklen_t) throws {
@@ -97,6 +117,10 @@ extension Socket {
         Glibc.accept(fd, addr, len)
     }
 
+    static func connect(_ fd: Int32, _ addr: UnsafePointer<sockaddr>!, _ len: socklen_t) -> Int32 {
+        Glibc.connect(fd, addr, len)
+    }
+
     static func read(_ fd: Int32, _ buffer: UnsafeMutableRawPointer!, _ nbyte: Int) -> Int {
         Glibc.read(fd, buffer, nbyte)
     }
@@ -107,6 +131,10 @@ extension Socket {
 
     static func close(_ fd: Int32) -> Int32 {
         Glibc.close(fd)
+    }
+
+    static func unlink(_ addr: UnsafePointer<CChar>!) -> Int32 {
+        return Glibc.unlink(addr)
     }
 
     static func poll(_ fds: UnsafeMutablePointer<pollfd>!, _ nfds: nfds_t, _ tmo_p: Int32) -> Int32 {

--- a/Sources/Socket/Socket+Glibc.swift
+++ b/Sources/Socket/Socket+Glibc.swift
@@ -94,6 +94,10 @@ extension Socket {
         Glibc.getpeername(fd, addr, len)
     }
 
+    static func getsockname(_ fd: Int32, _ addr: UnsafeMutablePointer<sockaddr>!, _ len: UnsafeMutablePointer<socklen_t>!) -> Int32 {
+        Glibc.getsockname(fd, addr, len)
+    }
+
     static func inet_ntop(_ domain: Int32, _ addr: UnsafeRawPointer!,
                           _ buffer: UnsafeMutablePointer<CChar>!, _ addrLen: socklen_t) throws {
         if Glibc.inet_ntop(domain, addr, buffer, addrLen) == nil {

--- a/Sources/Socket/SocketAddress.swift
+++ b/Sources/Socket/SocketAddress.swift
@@ -1,0 +1,160 @@
+//
+//  Socket+Address.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 15/03/2022.
+//  Copyright © 2022 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+public protocol SocketAddress {
+    static var family: sa_family_t { get }
+}
+
+public extension SocketAddress where Self == sockaddr_in {
+    static func makeINET(port: UInt16) -> Self {
+        Socket.makeAddressINET(port: port)
+    }
+}
+
+public extension SocketAddress where Self == sockaddr_in6 {
+    static func makeINET6(port: UInt16) -> Self {
+        Socket.makeAddressINET6(port: port)
+    }
+}
+
+public extension SocketAddress where Self == sockaddr_un {
+    static func makeUnix(path: String) -> Self {
+        Socket.makeAddressUnix(path: path)
+    }
+}
+
+extension sockaddr_in: SocketAddress {
+    public static let family = sa_family_t(AF_INET)
+}
+
+extension sockaddr_in6: SocketAddress {
+    public static let family = sa_family_t(AF_INET6)
+}
+
+extension sockaddr_un: SocketAddress {
+    public static let family = sa_family_t(AF_UNIX)
+}
+
+public extension SocketAddress {
+    static func make(from storage: sockaddr_storage) throws -> Self {
+        guard storage.ss_family == family else {
+            throw SocketError.unsupportedAddress
+        }
+        var storage = storage
+        return withUnsafePointer(to: &storage) {
+            $0.withMemoryRebound(to: Self.self, capacity: 1) {
+                $0.pointee
+            }
+        }
+    }
+}
+
+extension Socket {
+
+    enum Address: Hashable {
+        case ip4(String, port: UInt16)
+        case ip6(String, port: UInt16)
+        case unix(String)
+    }
+
+    static func makeAddress(from addr: sockaddr_storage) throws -> Address {
+        switch Int32(addr.ss_family) {
+        case AF_INET:
+            var addr_in = try sockaddr_in.make(from: addr)
+            let maxLength = socklen_t(INET_ADDRSTRLEN)
+            let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: Int(maxLength))
+            try Socket.inet_ntop(AF_INET, &addr_in.sin_addr, buffer, maxLength)
+            return .ip4(String(cString: buffer), port: UInt16(addr_in.sin_port).byteSwapped)
+
+        case AF_INET6:
+            var addr_in6 = try sockaddr_in6.make(from: addr)
+            let maxLength = socklen_t(INET_ADDRSTRLEN)
+            let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: Int(maxLength))
+            try Socket.inet_ntop(AF_INET6, &addr_in6.sin6_addr, buffer, maxLength)
+            return .ip6(String(cString: buffer), port: UInt16(addr_in6.sin6_port).byteSwapped)
+
+        case AF_UNIX:
+            var sockaddr_un = try sockaddr_un.make(from: addr)
+            return .unix(String(cString: &sockaddr_un.sun_path.0))
+
+        default:
+            throw SocketError.unsupportedAddress
+        }
+    }
+
+    static func makeInAddr(fromIP4 address: String) throws -> in_addr {
+        var addr = in_addr()
+        guard address.withCString({ Socket.inet_pton(AF_INET, $0, &addr) }) == 1 else {
+            throw SocketError.makeFailed("inet_pton AF_INET")
+        }
+        return addr
+    }
+
+    static func makeInAddr(fromIP6 address: String) throws -> in6_addr {
+        var addr = in6_addr()
+        guard address.withCString({ Socket.inet_pton(AF_INET6, $0, &addr) }) == 1 else {
+            throw SocketError.makeFailed("inet_pton AF_INET6")
+        }
+        return addr
+    }
+}
+
+struct AnySocketAddress {
+    let storage: sockaddr_storage
+    let length: socklen_t
+
+    init<A: SocketAddress>(_ addr: A) {
+        var addr = addr
+        self.storage = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr_storage.self, capacity: 1) {
+                $0.pointee
+            }
+        }
+        self.length = socklen_t(MemoryLayout<A>.size)
+    }
+
+#if canImport(Darwin)
+    init(_ addr: sockaddr_un) {
+        var addr = addr
+        self.storage = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr_storage.self, capacity: 1) {
+                $0.pointee
+            }
+        }
+        self.length = socklen_t(addr.sun_len)
+    }
+#endif
+
+    @available(*, unavailable, message: "use sockaddr_in, sockaddr_in6 and sockaddr_un.")
+    init(_ addr: sockaddr_storage) { fatalError() }
+}

--- a/Sources/Socket/SocketAddress.swift
+++ b/Sources/Socket/SocketAddress.swift
@@ -77,6 +77,15 @@ public extension SocketAddress {
             }
         }
     }
+
+    func makeStorage() -> sockaddr_storage {
+        var addr = self
+        return withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr_storage.self, capacity: 1) {
+                $0.pointee
+            }
+        }
+    }
 }
 
 extension Socket {
@@ -127,34 +136,4 @@ extension Socket {
         }
         return addr
     }
-}
-
-struct AnySocketAddress {
-    let storage: sockaddr_storage
-    let length: socklen_t
-
-    init<A: SocketAddress>(_ addr: A) {
-        var addr = addr
-        self.storage = withUnsafePointer(to: &addr) {
-            $0.withMemoryRebound(to: sockaddr_storage.self, capacity: 1) {
-                $0.pointee
-            }
-        }
-        self.length = socklen_t(MemoryLayout<A>.size)
-    }
-
-#if canImport(Darwin)
-    init(_ addr: sockaddr_un) {
-        var addr = addr
-        self.storage = withUnsafePointer(to: &addr) {
-            $0.withMemoryRebound(to: sockaddr_storage.self, capacity: 1) {
-                $0.pointee
-            }
-        }
-        self.length = socklen_t(addr.sun_len)
-    }
-#endif
-
-    @available(*, unavailable, message: "use sockaddr_in, sockaddr_in6 and sockaddr_un.")
-    init(_ addr: sockaddr_storage) { fatalError() }
 }

--- a/Sources/Socket/SocketError.swift
+++ b/Sources/Socket/SocketError.swift
@@ -35,6 +35,7 @@ enum SocketError: LocalizedError, Equatable {
     case failed(type: String, errno: Int32, message: String)
     case blocked
     case disconnected
+    case unsupportedAddress
 
     var errorDescription: String? {
         switch self {
@@ -44,6 +45,8 @@ enum SocketError: LocalizedError, Equatable {
             return "SocketError. Blocked"
         case .disconnected:
             return "SocketError. Disconnected"
+        case .unsupportedAddress:
+            return "SocketError. UnsupportedAddress"
         }
     }
 

--- a/Tests/HTTPConnectionTests.swift
+++ b/Tests/HTTPConnectionTests.swift
@@ -133,7 +133,22 @@ final class HTTPConnectionTests: XCTestCase {
         let count = try await connection.requests.reduce(0, { count, _ in count + 1 })
         XCTAssertEqual(count, 0)
 
-        try await connection.close()
+        try connection.close()
+    }
+
+    func testConnectionHostName() {
+        XCTAssertEqual(
+            HTTPConnection.makeIdentifer(from: .ip4("8.8.8.8", port: 8080)),
+            "8.8.8.8"
+        )
+        XCTAssertEqual(
+            HTTPConnection.makeIdentifer(from: .ip6("::1", port: 8080)),
+            "::1"
+        )
+        XCTAssertEqual(
+            HTTPConnection.makeIdentifer(from: .unix("/var/sock/fox")),
+            "/var/sock/fox"
+        )
     }
 }
 

--- a/Tests/HTTPServerTests.swift
+++ b/Tests/HTTPServerTests.swift
@@ -193,7 +193,7 @@ final class HTTPServerTests: XCTestCase {
     func testListeningLog_INETPort() {
         let addr = Socket.makeAddressINET(port: 1234)
         XCTAssertEqual(
-            PrintHTTPLogger.makeListening(on: AnySocketAddress(addr)),
+            PrintHTTPLogger.makeListening(on: addr.makeStorage()),
             "starting server port: 1234"
         )
     }
@@ -202,7 +202,7 @@ final class HTTPServerTests: XCTestCase {
         var addr = Socket.makeAddressINET(port: 1234)
         addr.sin_addr = try Socket.makeInAddr(fromIP4: "8.8.8.8")
         XCTAssertEqual(
-            PrintHTTPLogger.makeListening(on: AnySocketAddress(addr)),
+            PrintHTTPLogger.makeListening(on: addr.makeStorage()),
             "starting server 8.8.8.8:1234"
         )
     }
@@ -210,7 +210,7 @@ final class HTTPServerTests: XCTestCase {
     func testListeningLog_INET6Port() {
         let addr = Socket.makeAddressINET6(port: 5678)
         XCTAssertEqual(
-            PrintHTTPLogger.makeListening(on: AnySocketAddress(addr)),
+            PrintHTTPLogger.makeListening(on: addr.makeStorage()),
             "starting server port: 5678"
         )
     }
@@ -219,7 +219,7 @@ final class HTTPServerTests: XCTestCase {
         var addr = Socket.makeAddressINET6(port: 1234)
         addr.sin6_addr = try Socket.makeInAddr(fromIP6: "::1")
         XCTAssertEqual(
-            PrintHTTPLogger.makeListening(on: AnySocketAddress(addr)),
+            PrintHTTPLogger.makeListening(on: addr.makeStorage()),
             "starting server ::1:1234"
         )
     }
@@ -227,7 +227,7 @@ final class HTTPServerTests: XCTestCase {
     func testListeningLog_UnixPath() {
         let addr = Socket.makeAddressUnix(path: "/var/fox/xyz")
         XCTAssertEqual(
-            PrintHTTPLogger.makeListening(on: AnySocketAddress(addr)),
+            PrintHTTPLogger.makeListening(on: addr.makeStorage()),
             "starting server path: /var/fox/xyz"
         )
     }
@@ -236,7 +236,7 @@ final class HTTPServerTests: XCTestCase {
         var addr = Socket.makeAddressUnix(path: "/var/fox/xyz")
         addr.sun_family = sa_family_t(AF_IPX)
         XCTAssertEqual(
-            PrintHTTPLogger.makeListening(on: AnySocketAddress(addr)),
+            PrintHTTPLogger.makeListening(on: addr.makeStorage()),
             "starting server"
         )
     }

--- a/Tests/Socket+Pair.swift
+++ b/Tests/Socket+Pair.swift
@@ -64,15 +64,3 @@ extension Socket {
         return (s1, s2)
     }
 }
-
-extension SocketAddress {
-
-    func makeStorage() -> sockaddr_storage {
-        var addr = self
-        return withUnsafePointer(to: &addr) {
-            $0.withMemoryRebound(to: sockaddr_storage.self, capacity: 1) {
-                $0.pointee
-            }
-        }
-    }
-}

--- a/Tests/SocketAddressTests.swift
+++ b/Tests/SocketAddressTests.swift
@@ -1,0 +1,164 @@
+//
+//  SocketAddressTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 15/03/2022.
+//  Copyright © 2022 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingFox
+import XCTest
+import Foundation
+
+final class SocketAddressTests: XCTestCase {
+
+    func testINET_IsCorrectlyDecodedFromStorage() {
+        let storage = sockaddr_in
+            .makeINET(port: 8001)
+            .makeStorage()
+
+        XCTAssertEqual(
+            try sockaddr_in.make(from: storage)
+                .sin_port
+                .bigEndian,
+            8001
+        )
+    }
+
+    func testINET_ThrowsInvalidAddress_WhenFamilyIncorrect() {
+        let storage = sockaddr_un
+            .makeUnix(path: "/var")
+            .makeStorage()
+
+        XCTAssertThrowsError(
+            try sockaddr_in.make(from: storage),
+            of: SocketError.self
+        ) {
+            XCTAssertEqual($0, .unsupportedAddress)
+        }
+    }
+
+    func testAddress_DecodesIP4() throws {
+        var addr = Socket.makeAddressINET(port: 1080)
+        addr.sin_addr = try Socket.makeInAddr(fromIP4: "192.168.0.1")
+
+        XCTAssertEqual(
+            try Socket.makeAddress(from: addr.makeStorage()),
+            .ip4("192.168.0.1", port: 1080)
+        )
+    }
+
+    func testInvalidIP4_ThrowsError() {
+        XCTAssertThrowsError(
+            try Socket.makeInAddr(fromIP4: "192.168.0")
+        )
+        XCTAssertThrowsError(
+            try Socket.makeInAddr(fromIP4: "::1")
+        )
+    }
+
+    func testINET6_IsCorrectlyDecodedFromStorage() throws {
+        let storage = sockaddr_in6
+            .makeINET6(port: 8080)
+            .makeStorage()
+
+        XCTAssertEqual(
+            try sockaddr_in6.make(from: storage)
+                .sin6_port
+                .bigEndian,
+            8080
+        )
+    }
+
+    func testINET6_ThrowsInvalidAddress_WhenFamilyIncorrect() throws {
+        let storage = sockaddr_un
+            .makeUnix(path: "/var")
+            .makeStorage()
+
+        XCTAssertThrowsError(
+            try sockaddr_in6.make(from: storage),
+            of: SocketError.self
+        ) {
+            XCTAssertEqual($0, .unsupportedAddress)
+        }
+    }
+
+    func testAddress_DecodesIP6() throws {
+        var addr = Socket.makeAddressINET6(port: 5010)
+        addr.sin6_addr = try Socket.makeInAddr(fromIP6: "::1")
+
+        XCTAssertEqual(
+            try Socket.makeAddress(from: addr.makeStorage()),
+            .ip6("::1", port: 5010)
+        )
+    }
+
+    func testInvalidIP6_ThrowsError() {
+        XCTAssertThrowsError(
+            try Socket.makeInAddr(fromIP6: "192.168.0")
+        )
+        XCTAssertThrowsError(
+            try Socket.makeInAddr(fromIP6: ":10:::::")
+        )
+    }
+
+    func testUnix_IsCorrectlyDecodedFromStorage() throws {
+        let storage = sockaddr_un
+            .makeUnix(path: "/var")
+            .makeStorage()
+
+        var unix = try sockaddr_un.make(from: storage)
+        XCTAssertEqual(
+            String(cString: &unix.sun_path.0),
+            "/var"
+        )
+    }
+
+    func testUnix_ThrowsInvalidAddress_WhenFamilyIncorrect() {
+        let storage = sockaddr_in6
+            .makeINET6(port: 8080)
+            .makeStorage()
+
+        XCTAssertThrowsError(
+            try sockaddr_un.make(from: storage),
+            of: SocketError.self
+        ) {
+            XCTAssertEqual($0, .unsupportedAddress)
+        }
+    }
+
+    func testIPX_ThrowsInvalidAddress() {
+        var storage = sockaddr_storage()
+        storage.ss_family = sa_family_t(AF_IPX)
+
+        XCTAssertThrowsError(
+            try Socket.makeAddress(from: storage),
+            of: SocketError.self
+        ) {
+            XCTAssertEqual($0, .unsupportedAddress)
+        }
+    }
+}

--- a/Tests/SocketErrorTests.swift
+++ b/Tests/SocketErrorTests.swift
@@ -46,6 +46,7 @@ final class SocketErrorTests: XCTestCase {
         
         XCTAssertEqual(SocketError.blocked.errorDescription, "SocketError. Blocked")
         XCTAssertEqual(SocketError.disconnected.errorDescription, "SocketError. Disconnected")
+        XCTAssertEqual(SocketError.unsupportedAddress.errorDescription, "SocketError. UnsupportedAddress")
     }
 
     func testSocketError_makeFailed() {

--- a/Tests/SocketTests.swift
+++ b/Tests/SocketTests.swift
@@ -161,11 +161,39 @@ final class SocketTests: XCTestCase {
         )
     }
 
+    func testSocketBind_ToINET() throws {
+        let socket = try Socket(domain: AF_INET, type: Socket.stream)
+        let address = Socket.makeAddressINET(port: 8080).makeStorage()
+        XCTAssertNoThrow(
+            try socket.bind(to: address)
+        )
+    }
+
     func testSocketBind_ToINET6_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
         let address = Socket.makeAddressINET6(port: 8080)
         XCTAssertThrowsError(
-            try socket.bind(to: AnySocketAddress(address))
+            try socket.bind(to: address)
+        )
+    }
+
+    func testSocketBind_ToInvalidStorage_ThrowsUnsupported() {
+        let socket = Socket(file: -1)
+        var addr = Socket.makeAddressUnix(path: "/var/fox/xyz").makeStorage()
+        addr.ss_family = sa_family_t(AF_IPX)
+        XCTAssertThrowsError(
+            try socket.bind(to: addr),
+            of: SocketError.self
+        ) {
+            XCTAssertEqual($0, .unsupportedAddress)
+        }
+    }
+
+    func testSocketBind_ToStorage_ThrowsError_WhenInvalid() {
+        let socket = Socket(file: -1)
+        let address = Socket.makeAddressINET6(port: 8080).makeStorage()
+        XCTAssertThrowsError(
+            try socket.bind(to: address)
         )
     }
 
@@ -194,6 +222,20 @@ final class SocketTests: XCTestCase {
         let socket = Socket(file: -1)
         XCTAssertThrowsError(
             try socket.setFlags(.nonBlocking)
+        )
+    }
+
+    func testSocketRemotePeer_ThrowsError_WhenInvalid() {
+        let socket = Socket(file: -1)
+        XCTAssertThrowsError(
+            try socket.remotePeer()
+        )
+    }
+
+    func testSocket_sockname_ThrowsError_WhenInvalid() {
+        let socket = Socket(file: -1)
+        XCTAssertThrowsError(
+            try socket.sockname()
         )
     }
 

--- a/Tests/SocketTests.swift
+++ b/Tests/SocketTests.swift
@@ -127,77 +127,78 @@ final class SocketTests: XCTestCase {
         XCTAssertTrue(try socket.flags.contains(.append))
     }
 
-    func testSocketInit_ThrowsError_WhenInvalid() throws {
+    func testSocketInit_ThrowsError_WhenInvalid() {
         XCTAssertThrowsError(
             _ = try Socket(domain: -1, type: -1)
         )
     }
 
-    func testSocketAccept_ThrowsError_WhenInvalid() throws {
+    func testSocketAccept_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
         XCTAssertThrowsError(
             try socket.accept()
         )
     }
 
-    func testSocketClose_ThrowsError_WhenInvalid() throws {
+    func testSocketConnect_ThrowsError_WhenInvalid() {
+        let socket = Socket(file: -1)
+        XCTAssertThrowsError(
+            try socket.connect(to: .makeUnix(path: "test"))
+        )
+    }
+
+    func testSocketClose_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
         XCTAssertThrowsError(
             try socket.close()
         )
     }
 
-    func testSocketListen_ThrowsError_WhenInvalid() throws {
+    func testSocketListen_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
         XCTAssertThrowsError(
             try socket.listen()
         )
     }
 
-    func testSocketBindIP6_ThrowsError_WhenInvalid() throws {
+    func testSocketBind_ToINET6_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
+        let address = Socket.makeAddressINET6(port: 8080)
         XCTAssertThrowsError(
-            try socket.bindIP6(port: 8080)
+            try socket.bind(to: AnySocketAddress(address))
         )
     }
 
-    func testSocketBindIP6_ThrowsError_WhenListenAddressInvalid() throws {
-        let socket = try Socket(domain: AF_INET6, type: Socket.stream)
-        XCTAssertThrowsError(
-            try socket.bindIP6(port: 8080, listenAddress: "invalid address")
-        )
-    }
-
-    func testSocketGetOption_ThrowsError_WhenInvalid() throws {
+    func testSocketGetOption_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
         XCTAssertThrowsError(
             _ = try socket.getValue(for: .localAddressReuse)
         )
     }
 
-    func testSocketSetOption_ThrowsError_WhenInvalid() throws {
+    func testSocketSetOption_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
         XCTAssertThrowsError(
             try socket.setValue(true, for: .localAddressReuse)
         )
     }
 
-    func testSocketGetFlags_ThrowsError_WhenInvalid() throws {
+    func testSocketGetFlags_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
         XCTAssertThrowsError(
             _ = try socket.flags
         )
     }
 
-    func testSocketSetFlags_ThrowsError_WhenInvalid() throws {
+    func testSocketSetFlags_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
         XCTAssertThrowsError(
             try socket.setFlags(.nonBlocking)
         )
     }
 
-    func test_ntop_ThrowsError_WhenBufferIsTooSmall() throws {
-        var addr = sockaddr_in6()
+    func test_ntop_ThrowsError_WhenBufferIsTooSmall() {
+        var addr = Socket.makeAddressINET6(port: 8080)
         let maxLength = socklen_t(1)
         let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: Int(maxLength))
         XCTAssertThrowsError(try Socket.inet_ntop(AF_INET6, &addr.sin6_addr, buffer, maxLength))


### PR DESCRIPTION
Adds support for starting the HTTP server using a supported `sockaddr` type
- `sockaddr_in`
- `sockaddr_in6`
- `sockaddr_un`

Adds `protocol SocketAddress` to formalise the the relationship of these types.