### PR TITLE
Swift 5.6 on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    container: swift:5.5
+    container: swift:5.6
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Swift 5.6 docker containers are now available