### PR TITLE
GitHub Actions Monterey / Xcode 13.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Version
+        run: swift --version
       - name: Build and Test
         run: swift test --enable-code-coverage
       - name: Gather code coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,13 @@ on:
 jobs:
   macos:
     runs-on: macos-12
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.3.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: xcode-select
+        run: xcode-select -p
       - name: Version
         run: swift --version
       - name: Build and Test


### PR DESCRIPTION
Update GitHub actions to run on Xcode 13.3 on macOS 12