### PR TITLE
Standardize paths, fix path traversal

### DIFF
--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -88,7 +88,7 @@ struct HTTPDecoder {
     }
 
     static func makeComponents(from comps: URLComponents?) -> (path: String, query: [HTTPRequest.QueryItem]) {
-        let path = comps?.path ?? ""
+        let path = (comps?.path).flatMap { URL(string: $0)?.standardized.path } ?? ""
         let query = comps?.queryItems?.map {
             HTTPRequest.QueryItem(name: $0.name, value: $0.value ?? "")
         }

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -98,6 +98,26 @@ final class HTTPDecoderTests: XCTestCase {
         )
     }
 
+    func testNaughtyPath_IsParsed() async throws {
+        let request = try await HTTPDecoder.decodeRequestFromString(
+            """
+            GET /../a/b/../c/./d.html?fish=Chips&with=Mushy%20Peas HTTP/1.1\r
+            \r
+            """
+        )
+
+        XCTAssertEqual(
+            request.path,
+            "a/c/d.html"
+        )
+
+        XCTAssertEqual(
+            request.query,
+            [.init(name: "fish", value: "Chips"),
+             .init(name: "with", value: "Mushy Peas")]
+        )
+    }
+
     func testHeaders_AreParsed() async throws {
         let request = try await HTTPDecoder.decodeRequestFromString(
             """


### PR DESCRIPTION
As per RFC-3986 5.2.4 (Remove Dot Segments), we want to remove `..`s. We can use Foundation's `URL.standardized` features for that.

However, I am sleepy, so this may have missed something obvious.

Fixes swhitty/FlyingFox/issues/24