### PR TITLE
Fix security vulnerability in Socket.write (#26)

### DIFF
--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -226,7 +226,7 @@ public struct Socket: Sendable, Hashable {
     public func write(_ data: Data, from index: Data.Index) throws -> Data.Index {
         guard index < data.endIndex else { return data.endIndex }
         return try data.withUnsafeBytes { buffer in
-            let sent = try write(buffer.baseAddress! + index, length: data.endIndex - index)
+            let sent = try write(buffer.baseAddress! + index - data.startIndex, length: data.endIndex - index)
             return index + sent
         }
     }


### PR DESCRIPTION
The issue was caused by incorrect handling of data slices with non-zero start indices and could lead to arbitrary memory being leaked to the socket. See #26 for details.