### PR TITLE
Fix `SHA1.hash` for data slices on non-CryptoKit platforms

### DIFF
--- a/FlyingFox/Sources/WebSocket/SHA1.swift
+++ b/FlyingFox/Sources/WebSocket/SHA1.swift
@@ -97,8 +97,7 @@ extension SHA1 {
 
     static func hash<D: DataProtocol>(data: D) -> Data where D.Index == Int {
         // Convert the data to regular data in case it was a slice because slices can crash this hash algorithm
-        var data = Data()
-        data.append(data)
+        let data = Data(data)
 
         var digest = Digest()
         var w = ContiguousArray<UInt32>(repeating: 0, count: 80)

--- a/FlyingFox/Sources/WebSocket/SHA1.swift
+++ b/FlyingFox/Sources/WebSocket/SHA1.swift
@@ -96,6 +96,10 @@ extension SHA1 {
     }
 
     static func hash<D: DataProtocol>(data: D) -> Data where D.Index == Int {
+        // Convert the data to regular data in case it was a slice because slices can crash this hash algorithm
+        var data = Data()
+        data.append(data)
+
         var digest = Digest()
         var w = ContiguousArray<UInt32>(repeating: 0, count: 80)
 


### PR DESCRIPTION
The custom SHA1 hashing algorithm that FlyingFox uses when CryptoKit isn't available crashes when passed a data slice over 64 bytes in length. This is because [the first for loop in `SHA1.hash`](https://github.com/stackotter/FlyingFox/blob/aea293620ab5393c967f195d3e6d17e86796d216/FlyingFox/Sources/WebSocket/SHA1.swift#L106) assumes that the data's first index is 0.

To fix this I have added two lines to the start of the method which make a copy of the data to ensure that the algorithm is operating on regular data and not a slice.

## Reproducing the crash

The code below demonstrates the issue. The expected behaviour is that `slice` and `sliceEquivalent` have the same SHA1 hash. But what actually happens is that `SHA1.hash(data: slice)` crashes.

```swift
extension Data {
    func hexEncodedString() -> String {
        return self.map { String(format: "%02hhx", $0) }.joined()
    }
}

let data = (String(repeating: "abcd", count: 32) + String(repeating: "efgh", count: 32)).data(using: .utf8)!

// Both of these variables contain the same data, but the first is a slice and the second isn't
let slice = data[128...] // Contains "efgh" repeated 32 times (128 bytes)
let sliceEquivalent = String(repeating: "efgh", count: 32).data(using: .utf8)!

print(SHA1.hash(data: sliceEquivalent).hexEncodedString())
print(SHA1.hash(data: slice).hexEncodedString()) // Crashes without the fix
```