### PR TITLE
Conform WebSocketHTTPHandler to RFC 6455 section 4.2.1

### DIFF
--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -234,13 +234,13 @@ final class HTTPServerTests: XCTestCase {
         var request = HTTPRequest.make(path: "/socket")
         request.headers[.host] = "localhost"
         request.headers[.upgrade] = "websocket"
-        request.headers[.connection] = "Upgrade"
+        request.headers[.connection] = "Keep-Alive, Upgrade"
         request.headers[.webSocketVersion] = "13"
-        request.headers[.webSocketKey] = "ABC"
+        request.headers[.webSocketKey] = "ABCDEFGHIJKLMNOP".data(using: .utf8)!.base64EncodedString()
         try await socket.writeRequest(request)
 
         let response = try await socket.readResponse()
-        XCTAssertEqual(response.headers[.webSocketAccept], "YaxQU85y1o0znnviL0CeoKg7QTM=")
+        XCTAssertEqual(response.headers[.webSocketAccept], "9twnCz4Oi2Q3EuDqLAETCuip07c=")
         XCTAssertEqual(response.headers[.connection], "upgrade")
         XCTAssertEqual(response.headers[.upgrade], "websocket")
 

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -232,6 +232,7 @@ final class HTTPServerTests: XCTestCase {
         defer { try? socket.close() }
 
         var request = HTTPRequest.make(path: "/socket")
+        request.headers[.host] = "localhost"
         request.headers[.upgrade] = "websocket"
         request.headers[.connection] = "Upgrade"
         request.headers[.webSocketVersion] = "13"

--- a/FlyingFox/Tests/Handlers/WebSocketHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/WebSocketHandlerTests.swift
@@ -40,9 +40,9 @@ final class WebSocketHandlerTests: XCTestCase {
         let response = try await handler.handleRequest(.make(
             headers: [
                 .host: "localhost",
-                .connection: "uPgRaDe", // case-insensitive
+                .connection: "uPgRaDe,Keep-Alive", // case-insensitive and can be a list of values
                 .upgrade: "WeBsOcKeT", // case-insensitive
-                .webSocketKey: "ABC",
+                .webSocketKey: "ABCDEFGHIJKLMNOP".data(using: .utf8)!.base64EncodedString(),
                 .webSocketVersion: "13"
             ]
         ))
@@ -53,7 +53,7 @@ final class WebSocketHandlerTests: XCTestCase {
         )
         XCTAssertEqual(
             response.headers[.webSocketAccept],
-            "YaxQU85y1o0znnviL0CeoKg7QTM="
+            "9twnCz4Oi2Q3EuDqLAETCuip07c="
         )
         XCTAssertEqual(
             response.headers[.connection],
@@ -74,7 +74,7 @@ final class WebSocketHandlerTests: XCTestCase {
             .host: "localhost",
             .connection: "Upgrade",
             .upgrade: "websocket",
-            .webSocketKey: "ABC",
+            .webSocketKey: "ABCDEFGHIJKLMNOP".data(using: .utf8)!.base64EncodedString(),
             .webSocketVersion: "13"
         ]
 
@@ -87,8 +87,8 @@ final class WebSocketHandlerTests: XCTestCase {
         var incorrectUpgradeHeaders = headers
         incorrectUpgradeHeaders[.upgrade] = "webplugs"
 
-        var missingSocketKeyHeaders = headers
-        missingSocketKeyHeaders[.webSocketKey] = nil
+        var incorrectSocketKeyHeaders = headers
+        incorrectSocketKeyHeaders[.webSocketKey] = "ABC"
 
         var incorrectSocketVersionHeaders = headers
         incorrectSocketVersionHeaders[.webSocketVersion] = "-1"
@@ -111,9 +111,9 @@ final class WebSocketHandlerTests: XCTestCase {
             .badRequest
         )
 
-        let missingSocketKeyResponse = try await handler.handleRequest(.make(headers: missingSocketKeyHeaders))
+        let incorrectSocketKeyResponse = try await handler.handleRequest(.make(headers: incorrectSocketKeyHeaders))
         XCTAssertEqual(
-            missingSocketKeyResponse.statusCode,
+            incorrectSocketKeyResponse.statusCode,
             .badRequest
         )
 


### PR DESCRIPTION
[RFC 6455 section 4.2.1](https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.1) prescribes which headers are mandatory for a WebSocket handshake request to be correct. It also details what each of these headers should contain. This PR brings `WebSocketHTTPHander` up to spec (which has a typo by the way, but I didn't change that to keep this PR focussed).

I have documented the new code in a way that makes it easy to match up each check with its corresponding RFC rule (see `WebSocketHTTPHander.verifyHandshakeRequestHeaders`).

There is one conundrum that I ran into while implementing the checks, which is that rule 1 mandates that websocket connections must begin as `GET` requests, however in FlyingFox the method for websocket endpoints is up to users of the framework. We could add some kind of check to `appendRoute`, or we could just leave it given that developers will probably realise pretty quickly that their websocket won't work as a `POST` endpoint. Another option would be creating a separate method for hosting websocket endpoints such as `appendWebSocketRoute` which takes only a path and doesn't let developers specify the method.