### PR TITLE
Fix WebSocketHTTPHandler Typo

### DIFF
--- a/FlyingFox/Sources/HTTPHandler.swift
+++ b/FlyingFox/Sources/HTTPHandler.swift
@@ -70,8 +70,8 @@ public extension HTTPHandler where Self == ClosureHTTPHandler {
     }
 }
 
-public extension HTTPHandler where Self == WebSocketHTTPHander {
-    static func webSocket(_ handler: WSMessageHandler, frameSize: Int = 16384) -> WebSocketHTTPHander {
-        WebSocketHTTPHander(handler: MessageFrameWSHandler(handler: handler, frameSize: frameSize))
+public extension HTTPHandler where Self == WebSocketHTTPHandler {
+    static func webSocket(_ handler: WSMessageHandler, frameSize: Int = 16384) -> WebSocketHTTPHandler {
+        WebSocketHTTPHandler(handler: MessageFrameWSHandler(handler: handler, frameSize: frameSize))
     }
 }

--- a/FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift
@@ -1,5 +1,5 @@
 //
-//  WebSocketHTTPHander.swift
+//  WebSocketHTTPHandler.swift
 //  FlyingFox
 //
 //  Created by Simon Whitty on 19/03/2022.
@@ -39,7 +39,7 @@ public struct InvalidWebSocketHandshakeError: LocalizedError {
     }
 }
 
-public struct WebSocketHTTPHander: HTTPHandler, Sendable {
+public struct WebSocketHTTPHandler: HTTPHandler, Sendable {
 
     private let handler: WSHandler
 
@@ -132,3 +132,6 @@ public struct WebSocketHTTPHander: HTTPHandler, Sendable {
         }
     }
 }
+
+@available(*, unavailable, renamed: "WebSocketHTTPHandler")
+public typealias WebSocketHTTPHander = WebSocketHTTPHandler

--- a/FlyingFox/Tests/Handlers/WebSocketHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/WebSocketHandlerTests.swift
@@ -35,7 +35,7 @@ import XCTest
 final class WebSocketHandlerTests: XCTestCase {
 
     func testResponseIncludesExpectedHeaders() async throws {
-        let handler = WebSocketHTTPHander.make()
+        let handler = WebSocketHTTPHandler.make()
 
         let response = try await handler.handleRequest(.make(
             headers: [
@@ -68,7 +68,7 @@ final class WebSocketHandlerTests: XCTestCase {
     func testHandlerVerifiesHeaders() async throws {
         // Checks for conformance to RFC 6455 section 4.2.1 (https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.1)
 
-        let handler = WebSocketHTTPHander.make()
+        let handler = WebSocketHTTPHandler.make()
 
         let headers: [HTTPHeader: String] = [
             .host: "localhost",
@@ -126,21 +126,21 @@ final class WebSocketHandlerTests: XCTestCase {
 
     func testWebSocketKey_IsCreatedFromUUID() async throws {
         XCTAssertEqual(
-            WebSocketHTTPHander.makeSecWebSocketKeyValue(for: UUID(uuidString: "123e4567-e89b-12d3-a456-426614174000")!),
+            WebSocketHTTPHandler.makeSecWebSocketKeyValue(for: UUID(uuidString: "123e4567-e89b-12d3-a456-426614174000")!),
             "Ej5FZ+ibEtOkVkJmFBdAAA=="
         )
 
         XCTAssertNotEqual(
-            WebSocketHTTPHander.makeSecWebSocketKeyValue(),
+            WebSocketHTTPHandler.makeSecWebSocketKeyValue(),
             "Ej5FZ+ibEtOkVkJmFBdAAA=="
         )
     }
 
 }
 
-private extension WebSocketHTTPHander {
-    static func make(handler: WSHandler = MockHandler()) -> WebSocketHTTPHander {
-        WebSocketHTTPHander(handler: MockHandler())
+private extension WebSocketHTTPHandler {
+    static func make(handler: WSHandler = MockHandler()) -> WebSocketHTTPHandler {
+        WebSocketHTTPHandler(handler: MockHandler())
     }
 }
 

--- a/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
@@ -320,7 +320,7 @@ final class WSFrameEncoderTests: XCTestCase {
         let socket = try await AsyncSocket.connected(to: addr, pool: .polling)
         defer { try? socket.close() }
 
-        let key = WebSocketHTTPHander.makeSecWebSocketKeyValue()
+        let key = WebSocketHTTPHandler.makeSecWebSocketKeyValue()
 
         var request = HTTPRequest.make(path: "/mirror")
         request.headers[.host] = "ws.vi-server.org"
@@ -335,7 +335,7 @@ final class WSFrameEncoderTests: XCTestCase {
 
         XCTAssertEqual(
             response.headers[.webSocketAccept],
-            WebSocketHTTPHander.makeSecWebSocketAcceptValue(for: key)
+            WebSocketHTTPHandler.makeSecWebSocketAcceptValue(for: key)
         )
         print(String(data: HTTPEncoder.encodeResponse(response), encoding: .utf8)!)
 


### PR DESCRIPTION
Fixes typo in `WebSocketHTTPHandler` name

`WebSocketHTTPHander` -> `WebSocketHTTPHandler`

Adds unavailable declaration with the rename to assist any clients using it.