### PR TITLE
PollingSocketPool loop interval

### DIFF
--- a/FlyingFox/Tests/AsyncSocketTests.swift
+++ b/FlyingFox/Tests/AsyncSocketTests.swift
@@ -35,12 +35,12 @@ import Foundation
 
 extension AsyncSocket {
 
-    static func make(pool: AsyncSocketPool = .polling) throws -> AsyncSocket {
+    static func make(pool: AsyncSocketPool = .pollingClient) throws -> AsyncSocket {
         let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
         return try AsyncSocket(socket: socket, pool: pool)
     }
 
-    static func makePair(pool: AsyncSocketPool = .polling) throws -> (AsyncSocket, AsyncSocket) {
+    static func makePair(pool: AsyncSocketPool = .pollingClient) throws -> (AsyncSocket, AsyncSocket) {
         let (file1, file2) = Socket.socketpair(AF_UNIX, Socket.stream, 0)
         guard file1.rawValue > -1, file2.rawValue > -1 else {
             throw SocketError.makeFailed("SocketPair")

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -154,7 +154,7 @@ final class HTTPServerTests: XCTestCase {
         }
         let task = try await server.startDetached()
         defer { task.cancel() }
-        let socket = try await AsyncSocket.connected(to: address, pool: .polling)
+        let socket = try await AsyncSocket.connected(to: address)
         defer { try? socket.close() }
         try await socket.writeRequest(.make())
 
@@ -173,7 +173,7 @@ final class HTTPServerTests: XCTestCase {
         let task = try await server.startDetached()
         defer { task.cancel( )}
 
-        let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: 8080), pool: .polling)
+        let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: 8080))
         defer { try? socket.close() }
 
         try await socket.writeRequest(.make())
@@ -228,7 +228,7 @@ final class HTTPServerTests: XCTestCase {
         let task = try await server.startDetached()
         defer { task.cancel() }
 
-        let socket = try await AsyncSocket.connected(to: address, pool: .polling)
+        let socket = try await AsyncSocket.connected(to: address)
         defer { try? socket.close() }
 
         var request = HTTPRequest.make(path: "/socket")

--- a/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
@@ -317,7 +317,7 @@ final class WSFrameEncoderTests: XCTestCase {
 
     func debug_testWebSocketConnectionToVI() async throws {
         let addr = try Socket.makeAddressINET(fromIP4: "192.236.209.31", port: 80)
-        let socket = try await AsyncSocket.connected(to: addr, pool: .polling)
+        let socket = try await AsyncSocket.connected(to: addr)
         defer { try? socket.close() }
 
         let key = WebSocketHTTPHandler.makeSecWebSocketKeyValue()

--- a/FlyingSocks/Sources/AsyncSocket.swift
+++ b/FlyingSocks/Sources/AsyncSocket.swift
@@ -38,8 +38,8 @@ public protocol AsyncSocketPool: Sendable {
 }
 
 public extension AsyncSocketPool where Self == PollingSocketPool {
-    static var polling: AsyncSocketPool {
-        PollingSocketPool.shared
+    static var pollingClient: AsyncSocketPool {
+        PollingSocketPool.client
     }
 }
 
@@ -48,13 +48,13 @@ public struct AsyncSocket: Sendable {
     public let socket: Socket
     let pool: AsyncSocketPool
 
-    public init(socket: Socket, pool: AsyncSocketPool = .polling) throws {
+    public init(socket: Socket, pool: AsyncSocketPool = .pollingClient) throws {
         self.socket = socket
         self.pool = pool
         try socket.setFlags(.nonBlocking)
     }
 
-    public static func connected<A: SocketAddress>(to address: A,  pool: AsyncSocketPool = .polling) async throws -> Self {
+    public static func connected<A: SocketAddress>(to address: A,  pool: AsyncSocketPool = .pollingClient) async throws -> Self {
         let socket = try Socket(domain: Int32(address.makeStorage().ss_family), type: Socket.stream)
         let asyncSocket = try AsyncSocket(socket: socket, pool: pool)
         try await asyncSocket.connect(to: address)

--- a/FlyingSocks/Tests/AsyncSocketTests.swift
+++ b/FlyingSocks/Tests/AsyncSocketTests.swift
@@ -152,12 +152,12 @@ final class AsyncSocketTests: XCTestCase {
 
 extension AsyncSocket {
 
-    static func make(pool: AsyncSocketPool = .polling) throws -> AsyncSocket {
+    static func make(pool: AsyncSocketPool = .pollingClient) throws -> AsyncSocket {
         let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
         return try AsyncSocket(socket: socket, pool: pool)
     }
 
-    static func makePair(pool: AsyncSocketPool = .polling) throws -> (AsyncSocket, AsyncSocket) {
+    static func makePair(pool: AsyncSocketPool = .pollingClient) throws -> (AsyncSocket, AsyncSocket) {
         let (file1, file2) = Socket.socketpair(AF_UNIX, Socket.stream, 0)
         guard file1.rawValue > -1, file2.rawValue > -1 else {
             throw SocketError.makeFailed("SocketPair")


### PR DESCRIPTION
Allows `PollingSocketPool` to be created with 2 intervals;

- `pollInterval`: timeout passed to `poll(2)`
- `loopInterval`: Task.sleep timeout optional used for each loop iteration.
