### PR TITLE
Make FlyingFox pass tests without warnings/crashes in Xcode 14 beta 4

### DIFF
--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -55,7 +55,7 @@ public final actor HTTPServer {
         self.handlers = Self.makeRootHandler(to: handler)
     }
 
-    public convenience init(port: UInt16,
+    public init(port: UInt16,
                             timeout: TimeInterval = 15,
                             pool: AsyncSocketPool = defaultPool(),
                             logger: HTTPLogging? = defaultLogger(),
@@ -72,7 +72,7 @@ public final actor HTTPServer {
                   handler: handler)
     }
 
-    public convenience init(port: UInt16,
+    public init(port: UInt16,
                             timeout: TimeInterval = 15,
                             pool: AsyncSocketPool = defaultPool(),
                             logger: HTTPLogging? = defaultLogger(),

--- a/FlyingSocks/Sources/SocketAddress.swift
+++ b/FlyingSocks/Sources/SocketAddress.swift
@@ -137,8 +137,9 @@ extension Socket {
 
         case AF_UNIX:
             var sockaddr_un = try sockaddr_un.make(from: addr)
-            return .unix(String(cString: &sockaddr_un.sun_path.0))
-
+            return withUnsafePointer(to: &sockaddr_un.sun_path.0) {
+                return .unix(String(cString: $0))
+            }
         default:
             throw SocketError.unsupportedAddress
         }

--- a/FlyingSocks/Tests/PollingSocketPoolTests.swift
+++ b/FlyingSocks/Tests/PollingSocketPoolTests.swift
@@ -135,7 +135,7 @@ final class PollingSocketPoolTests: XCTestCase {
 
 private extension PollingSocketPool {
 
-    convenience init() {
+    init() {
         self.init(pollInterval: .immediate, loopInterval: .immediate)
     }
 }

--- a/FlyingSocks/Tests/SocketAddressTests.swift
+++ b/FlyingSocks/Tests/SocketAddressTests.swift
@@ -140,8 +140,11 @@ final class SocketAddressTests: XCTestCase {
             .makeStorage()
 
         var unix = try sockaddr_un.make(from: storage)
+        let path = withUnsafePointer(to: &unix.sun_path.0) {
+            return String(cString: $0)
+        }
         XCTAssertEqual(
-            String(cString: &unix.sun_path.0),
+            path,
             "/var"
         )
     }


### PR DESCRIPTION
I was testing FlyingFox on Xcode 14 (planning on offering/contributing some new features, love this project :) ) and found that the tests crashed on some unsafePointer stuff, and traced it to this PR: https://github.com/apple/swift/pull/42002

Most likely the usage of the new inout APIs will be considered wrong, so wanted to send in this to help in the mean time.

Feel free to reject on the basis that Xcode 14 is beta and that you only support mainline builds of Xcode, but I think the unsafePointer changes are safe to include, on the basis that it enforces the usage of the UnsafePointer<CChar> API and not the inout version.

The convenience removal was also a warning in Xcode 14 beta 4 (at least), unclear if that will be an issue in previous versions of Xcode (personal computer only has the latest edge macOS and Xcode versions :p )

