### PR TITLE
Xcode 14 Beta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,18 @@ jobs:
         with:
           files: ./coverage_report.lcov
 
+  xcode_14_beta:
+    runs-on: macos-12
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Version
+        run: swift --version
+      - name: Build and Test
+        run: swift test
+
   xcode_13_2_1:
     runs-on: macos-11
     env:


### PR DESCRIPTION
Adds GitHub Actions job to build and run tests using Xcode 14 beta.