### PR TITLE
Stop server by allowing existing connections to disconnect first

### DIFF
--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -115,11 +115,7 @@ public final actor HTTPServer {
     /// Stops the server by closing the listening socket and waiting for all connections to disconnect.
     /// - Parameter timeout: Seconds to allow for connections to close before server task is cancelled.
     public func stop(timeout: TimeInterval = 0) async {
-        guard let (socket, task) = state,
-              timeout > 0 else {
-            state?.task.cancel()
-            return
-        }
+        guard let (socket, task) = state else { return }
         try? socket.close()
         try? await task.getValue(cancelling: .afterTimeout(seconds: timeout))
     }

--- a/FlyingFox/Sources/Task+Timeout.swift
+++ b/FlyingFox/Sources/Task+Timeout.swift
@@ -82,7 +82,12 @@ extension Task {
                 cancel()
             }
         case .afterTimeout(let seconds):
-            return try await getValue(cancellingAfter: seconds)
+            if seconds > 0 {
+                return try await getValue(cancellingAfter: seconds)
+            } else {
+                cancel()
+                return try await value
+            }
         }
     }
 

--- a/FlyingFox/Sources/Task+Timeout.swift
+++ b/FlyingFox/Sources/Task+Timeout.swift
@@ -59,3 +59,45 @@ extension Task where Success: Sendable, Failure == Error {
         }
     }
 }
+
+extension Task {
+
+    enum CancellationPolicy {
+        /// Cancels the task when the task retrieving the value is cancelled
+        case whenParentIsCancelled
+
+        /// Cancels the task after a timeout elapses
+        case afterTimeout(seconds: TimeInterval)
+    }
+
+    /// Waits for the task to complete, cancelling the task according to the provided policy
+    /// - Parameter policy: Policy that defines how the task should be cancelled.
+    /// - Returns: The task value
+    func getValue(cancelling policy: CancellationPolicy) async throws -> Success {
+        switch policy {
+        case .whenParentIsCancelled:
+            return try await withTaskCancellationHandler {
+                try await value
+            } onCancel: {
+                cancel()
+            }
+        case .afterTimeout(let seconds):
+            return try await getValue(cancellingAfter: seconds)
+        }
+    }
+
+    private func getValue(cancellingAfter seconds: TimeInterval) async throws -> Success {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                _ = try await getValue(cancelling: .whenParentIsCancelled)
+            }
+            group.addTask {
+                try await Task<Never, Never>.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw TimeoutError()
+            }
+            _ = try await group.next()!
+            group.cancelAll()
+            return try await value
+        }
+    }
+}

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -227,7 +227,7 @@ final class HTTPServerTests: XCTestCase {
         let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: 8081))
         defer { try? socket.close() }
 
-        try await Task.sleep(seconds: 0.1)
+        try await Task.sleep(seconds: 0.5)
         let taskStop = Task { await server.stop(timeout: 10) }
 
         try await socket.writeRequest(.make())

--- a/FlyingSocks/Sources/AsyncSocket.swift
+++ b/FlyingSocks/Sources/AsyncSocket.swift
@@ -166,6 +166,12 @@ public struct AsyncSocketSequence: AsyncSequence, AsyncIteratorProtocol, Sendabl
     public func makeAsyncIterator() -> AsyncSocketSequence { self }
 
     public mutating func next() async throws -> AsyncSocket? {
-        try await socket.accept()
+        do {
+            return try await socket.accept()
+        } catch SocketError.disconnected {
+            return nil
+        } catch {
+            throw error
+        }
     }
 }


### PR DESCRIPTION
Because FlyingFox uses structured concurrency care has been taken to ensure all child tasks run under a single parent task. The server starts and spawns 2 child tasks;
- run `AsyncSocketPool` enabling async sockets
- listen for connections
   - each connect then gets its own task to process requests  
```
          ┌─────┐                       
          │Start│                       
          └─────┘                       
             │                          
     ┌───────┴───────┐                  
     ▼               ▼                  
┌────────┐      ┌────────┐              
│  Pool  │      │ Listen │              
└────────┘      └────────┘              
                     │                  
        ┌────────────┼────────────┐     
        │            │            │     
        ▼            ▼            ▼     
  ┌──────────┐ ┌──────────┐ ┌──────────┐
  │Connection│ │Connection│ │Connection│
  └──────────┘ └──────────┘ └──────────┘
```

Presently the only way to stop the server is to cancel the top level parent task that started the server. This is the fastest way to stop the server as it triggers cancellation in all of the child tasks allowing them to immediately begin finalising any work and completing.

@sergiocampama[ originally proposed](https://github.com/swhitty/FlyingFox/pull/36) that stopping the server could immediately stop accepting incoming connections and existing connections should be allowed to complete before the parent task is cancelled.

This PR enables this by adding `stop(timeout: TimeInterval) async` method to `HTTPServer` which closes the listening socket allowing its socket sequence to end, then all connection tasks waited to complete, finally `SocketError.disconnected` is thrown.

```
          ┌─────┐            ┌─────┐    
          │Start│◀──close()──│Stop │    
          └─────┘            └─────┘    
             │                          
     ┌───────┴───────┐                  
     ▼               ▼                  
┌────────┐      ┌────────┐              
│  Pool  │      │ Listen │              
└────────┘      └────────┘              
                     │                  
                     ▼                  
      throw SocketError.disconnected    
```

A timeout is provided to `stop(timeout: TimeInterval)` because some connections may not disconnect in a timely manner — WebSockets or `Connection: keep-alive`,  the Task is then cancelled after the timeout elapses.

```
          ┌─────┐            ┌─────┐
          │Start│◀──cancel()─│Stop │
          └─────┘            └─────┘
             │                      
     ┌───────┴───────┐              
     ▼               ▼              
┌────────┐      ┌────────┐          
│  Pool  │      │ Listen │          
└────────┘      └────────┘          
                     │              
                     │              
                     │              
                     ▼              
               ┌──────────┐         
               │Connection│         
               └──────────┘         
```

### Future Directions
It would be possible to keep a reference to every `HTTPConnection` so `stop()` is able reach in and complete the connections request sequence, ending any connections with `Connection: keep-alive`. 

WebSockets are another thing all together, it may be possible to somehow inject a `WSFrame.close()` into the frame sequence. In the meantime the timeout takes care of these connections.
