### PR TITLE
HTTPServer listeningAddress

### DIFF
--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -84,6 +84,10 @@ public final actor HTTPServer {
                   handler: ClosureHTTPHandler(handler))
     }
 
+    public var listeningAddress: Socket.Address? {
+        try? state?.socket.sockname()
+    }
+
     public func appendRoute(_ route: HTTPRoute, to handler: HTTPHandler) {
         handlers.appendRoute(route, to: handler)
     }


### PR DESCRIPTION
Exposes the currently listening address of `HTTPServer`.  Once the server is started and listening the bound port can be retrieved;

```swift
let server = HTTPServer(address: .loopback(port: 0))
Task { try await server.run() }

try await server.waitUntilListening()

switch await server.listeningAddress {
case let .ip4(_, port: port),
     let .ip6(_, port: port):
  return port
default:
  return nil
}
```

Many thanks to @karwa for the suggestion https://github.com/swhitty/FlyingFox/issues/41