### PR TITLE
AsyncSocketPool kqueue

### DIFF
--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -97,6 +97,7 @@ public final actor HTTPServer {
     }
 
     public func start() async throws {
+        try await pool.prepare()
         let socket = try makeSocketAndListen()
         do {
             let task = Task { try await start(on: socket, pool: pool) }

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -396,8 +396,8 @@ extension Task where Success == Never, Failure == Never {
     }
 }
 
-
 private struct SleepingPool: AsyncSocketPool {
+    func prepare() async throws { }
     func run() async throws { }
 
     func suspendSocket(_ socket: Socket, untilReadyFor events: Socket.Events) async throws {

--- a/FlyingSocks/Sources/AsyncSocket.swift
+++ b/FlyingSocks/Sources/AsyncSocket.swift
@@ -32,8 +32,8 @@
 import Foundation
 
 public protocol AsyncSocketPool: Sendable {
+    func prepare() async throws
     func run() async throws
-
     func suspendSocket(_ socket: Socket, untilReadyFor events: Socket.Events) async throws
 }
 

--- a/FlyingSocks/Sources/EventQueue+kQueue.swift
+++ b/FlyingSocks/Sources/EventQueue+kQueue.swift
@@ -1,0 +1,183 @@
+//
+//  EventQueue+kQueue.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 10/09/2022.
+//  Copyright © 2022 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+#if canImport(Darwin)
+import Darwin
+
+extension AsyncSocketPool where Self == EventQueueSocketPool<kQueue> {
+    static func eventQueue() -> EventQueueSocketPool<kQueue> {
+        EventQueueSocketPool<kQueue>(queue: kQueue())
+    }
+}
+
+struct kQueue: EventQueue {
+
+    private(set) var file: Socket.FileDescriptor
+    private(set) var existing: [Socket.FileDescriptor: Socket.Events]
+
+    init() {
+        self.file = .invalid
+        self.existing = [:]
+    }
+
+    mutating func reset() throws {
+        existing = [:]
+        try Self.closeQueue(file: file)
+    }
+
+    mutating func prepare() throws {
+        try reset()
+        self.file = try Self.makeQueue()
+    }
+
+    mutating func addEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {
+        for event in events {
+            var socketEvents = existing[socket] ?? []
+            if !socketEvents.contains(event) {
+                try addEvent(event, for: socket)
+                socketEvents.insert(event)
+                existing[socket] = socketEvents
+            }
+        }
+    }
+
+    func addEvent(_ event: Socket.Event, for socket: Socket.FileDescriptor) throws {
+        var event = Darwin.kevent(
+            ident: UInt(socket.rawValue),
+            filter: event.kqueueFilter,
+            flags: UInt16(EV_ADD | EV_ENABLE),
+            fflags: 0,
+            data: 0,
+            udata: nil
+        )
+        guard kevent(file.rawValue, &event, 1, nil, 0, nil) != -1 else {
+            throw SocketError.makeFailed("kqueue add kevent")
+        }
+    }
+
+    mutating func removeEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {
+        for event in events {
+            if var entries = existing[socket] {
+                if entries.contains(event) {
+                    try removeEvent(event, for: socket)
+                    entries.remove(event)
+                    if entries.isEmpty {
+                        existing[socket] = nil
+                    } else {
+                        existing[socket] = entries
+                    }
+                }
+            }
+        }
+    }
+
+    func removeEvent(_ event: Socket.Event, for socket: Socket.FileDescriptor) throws {
+        var event = Darwin.kevent(
+            ident: UInt(socket.rawValue),
+            filter: event.kqueueFilter,
+            flags: UInt16(EV_DELETE | EV_DISABLE),
+            fflags: 0,
+            data: 0,
+            udata: nil
+        )
+        guard kevent(file.rawValue, &event, 1, nil, 0, nil) != -1 else {
+            throw SocketError.makeFailed("kqueue remove kevent")
+        }
+    }
+
+    func getNotifications(max count: Int32) throws -> [EventNotification] {
+        var events = Array(repeating: kevent(), count: Int(count))
+        let status = kevent(file.rawValue, nil, 0, &events, count, nil)
+        guard status > 0 else {
+            throw SocketError.makeFailed("kqueue kevent")
+        }
+
+        return events
+            .prefix(Int(status))
+            .compactMap(EventNotification.make)
+    }
+
+    static func makeQueue(file: Int32 = Darwin.kqueue()) throws -> Socket.FileDescriptor {
+        let file = Socket.FileDescriptor(rawValue: file)
+        guard file != .invalid else {
+            throw SocketError.makeFailed("kqueue")
+        }
+        return file
+    }
+
+    static func closeQueue(file: Socket.FileDescriptor) throws {
+        guard file != .invalid else { return }
+        guard Socket.close(file.rawValue) >= 0 else {
+            throw SocketError.makeFailed("kqueue")
+        }
+    }
+}
+
+extension EventNotification {
+
+    static func make(from event: kevent) -> Self? {
+        guard let filter = Socket.Event.make(from: event.filter) else {
+            return nil
+        }
+        var notification = EventNotification(
+            file: .init(rawValue: Int32(event.ident)),
+            events: [filter],
+            errors: []
+        )
+
+        if filter == .write && (event.flags & UInt16(EV_EOF)) == EV_EOF {
+            notification.errors.insert(.endOfFile)
+        }
+        if (event.flags & UInt16(EV_ERROR)) == EV_ERROR {
+            notification.errors.insert(.error)
+        }
+
+        return notification
+    }
+}
+
+extension Socket.Event {
+    var kqueueFilter: Int16 {
+        switch self {
+        case .read: return Int16(EVFILT_READ)
+        case .write: return Int16(EVFILT_WRITE)
+        }
+    }
+
+    static func make(from filter: Int16) -> Self? {
+        switch Int32(filter) {
+        case EVFILT_READ: return .read
+        case EVFILT_WRITE: return .write
+        default: return nil
+        }
+    }
+}
+#endif

--- a/FlyingSocks/Sources/EventQueueSocketPool.swift
+++ b/FlyingSocks/Sources/EventQueueSocketPool.swift
@@ -1,0 +1,234 @@
+//
+//  EventQueueSocketPool.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 10/09/2022.
+//  Copyright © 2022 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Dispatch
+import Foundation
+
+protocol EventQueue {
+    mutating func prepare() throws
+    mutating func reset() throws
+    mutating func addEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws
+    mutating func removeEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws
+    func getNotifications(max count: Int32) throws -> [EventNotification]
+}
+
+struct EventNotification: Equatable {
+    var file: Socket.FileDescriptor
+    var events: Socket.Events
+    var errors: Set<Error>
+
+    enum Error {
+        case endOfFile
+        case error
+    }
+}
+
+#if canImport(Darwin)
+// temporary public interface
+public func makeEventQueuePool() -> AsyncSocketPool {
+    .eventQueue()
+}
+#endif
+
+final actor EventQueueSocketPool<Queue: EventQueue>: AsyncSocketPool {
+
+    private(set) var queue: Queue
+    private let dispatchQueue: DispatchQueue
+    private(set) var state: State?
+
+    init(queue: Queue, dispatchQueue: DispatchQueue = .init(label: "flyingfox")) {
+        self.queue = queue
+        self.dispatchQueue = dispatchQueue
+    }
+
+    func prepare() async throws {
+        try queue.prepare()
+        state = .ready
+    }
+
+    func run() async throws {
+        guard state == .ready else { throw Error("Not Ready") }
+        state = .running
+        defer { cancellAll() }
+
+        repeat {
+            if waiting.isEmpty {
+                try await suspendUntilContinuationsExist()
+            }
+            try await processNotifications(getNotifications())
+        } while true
+    }
+
+    func suspendSocket(_ socket: Socket, untilReadyFor events: Socket.Events) async throws {
+        guard state == .running || state == .ready else { throw Error("Not Ready") }
+        let continuation = Continuation()
+        defer { removeContinuation(continuation, for: socket.file) }
+        try appendContinuation(continuation, for: socket.file, events: events)
+        return try await continuation.value
+    }
+
+    private func getNotifications() async throws -> [EventNotification] {
+        let continuation = CancellingContinuation<[EventNotification], Swift.Error>()
+        dispatchQueue.async { [queue] in
+            let result = Result {
+                try queue.getNotifications(max: 5)
+            }
+            continuation.resume(with: result)
+        }
+        return try await continuation.value
+    }
+
+    private func processNotifications(_ notifications: [EventNotification]) {
+        for notification in notifications {
+            processNotification(notification)
+        }
+    }
+
+    private func processNotification(_ notification: EventNotification) {
+        let continuations = waiting.continuations(
+            for: notification.file,
+            events: notification.events
+        )
+
+        if notification.errors.isEmpty {
+            for c in continuations {
+                c.resume()
+            }
+        } else {
+            for c in continuations {
+                c.resume(throwing: .disconnected)
+            }
+        }
+    }
+
+    enum State {
+        case ready
+        case running
+        case complete
+    }
+
+    private func cancellAll() {
+        try? queue.reset()
+        state = .complete
+        waiting.cancellAll()
+        waiting = Waiting()
+        loop?.cancel()
+        loop = nil
+    }
+
+    typealias Continuation = CancellingContinuation<Void, SocketError>
+    private var loop: CancellingContinuation<Void, Never>?
+    private var waiting = Waiting() {
+        didSet {
+            if !waiting.isEmpty, let continuation = loop {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func suspendUntilContinuationsExist() async throws {
+        let continuation = CancellingContinuation<Void, Never>()
+        loop = continuation
+        defer { loop = nil }
+        return try await continuation.value
+    }
+
+    private func appendContinuation(_ continuation: Continuation,
+                                    for socket: Socket.FileDescriptor,
+                                    events: Socket.Events) throws {
+        let events = waiting.appendContinuation(continuation,
+                                                for: socket,
+                                                events: events)
+        try queue.addEvents(events, for: socket)
+    }
+
+    private func removeContinuation(_ continuation: Continuation,
+                                    for socket: Socket.FileDescriptor) {
+        let events = waiting.removeContinuation(continuation, for: socket)
+        try? queue.removeEvents(events, for: socket)
+    }
+
+    private struct Error: LocalizedError {
+        var errorDescription: String?
+
+        init(_ description: String) {
+            self.errorDescription = description
+        }
+    }
+
+    struct Waiting {
+        private var storage: [Socket.FileDescriptor: [Continuation: Socket.Events]] = [:]
+
+        var isEmpty: Bool { storage.isEmpty }
+
+        // Adds continuation returning all events required by all waiters
+        mutating func appendContinuation(_ continuation: Continuation,
+                                         for socket: Socket.FileDescriptor,
+                                         events: Socket.Events) -> Socket.Events {
+            var entries = storage[socket] ?? [:]
+            entries[continuation] = events
+            storage[socket] = entries
+            return entries.values.reduce(Socket.Events()) {
+                $0.union($1)
+            }
+        }
+
+        // Removes continuation returning any events that are no longer being waited
+        mutating func removeContinuation(_ continuation: Continuation,
+                                         for socket: Socket.FileDescriptor) -> Socket.Events {
+            var entries = storage[socket] ?? [:]
+            guard let events = entries[continuation] else { return [] }
+            entries[continuation] = nil
+            storage[socket] = entries.isEmpty ? nil : entries
+            let remaining = entries.values.reduce(Socket.Events()) {
+                $0.union($1)
+            }
+            return events.filter { !remaining.contains($0) }
+        }
+
+        func continuations(for socket: Socket.FileDescriptor, events: Socket.Events) -> [Continuation] {
+            let entries = storage[socket] ?? [:]
+            return entries.compactMap { c, ev in
+                if events.intersection(ev).isEmpty {
+                    return nil
+                } else {
+                    return c
+                }
+            }
+        }
+
+        func cancellAll() {
+            for continuation in storage.values.flatMap(\.keys) {
+                continuation.cancel()
+            }
+        }
+    }
+}

--- a/FlyingSocks/Sources/PollingSocketPool.swift
+++ b/FlyingSocks/Sources/PollingSocketPool.swift
@@ -46,6 +46,8 @@ public final actor PollingSocketPool: AsyncSocketPool {
         self.loopInterval = loopInterval
     }
 
+    public func prepare() async throws { }
+
     public func suspendSocket(_ socket: Socket, untilReadyFor events: Socket.Events) async throws {
         let socket = SuspendedSocket(file: socket.file, events: events)
         let continuation = Continuation()

--- a/FlyingSocks/Tests/EventQueue+kQueueTests.swift
+++ b/FlyingSocks/Tests/EventQueue+kQueueTests.swift
@@ -1,0 +1,240 @@
+//
+//  EventQueue+kQueueTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 10/09/2022.
+//  Copyright © 2022 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+#if canImport(Darwin)
+@testable import FlyingSocks
+import XCTest
+
+final class kQueueTests: XCTestCase {
+
+    func testQueueCloses() throws {
+        var queue = try kQueue.make()
+        XCTAssertNoThrow(try queue.reset())
+    }
+
+    func testQueueThrowsError_Closes() throws {
+        XCTAssertThrowsError(try kQueue.closeQueue(file: .validMock))
+    }
+
+    func testQueueThrowsError_Make() throws {
+        XCTAssertThrowsError(try kQueue.makeQueue(file: -1))
+    }
+
+    func testAddingEventToInvalidDescriptor_ThrowsError() throws {
+        let queue = try kQueue.make()
+
+        XCTAssertThrowsError(
+            try queue.addEvent(.read, for: .validMock)
+        )
+    }
+
+    func testAddingAndRemovingEvents() throws {
+        var queue = try kQueue.make()
+        let (s1, _) = try Socket.makeNonBlockingPair()
+
+        XCTAssertNoThrow(try queue.addEvents(.connection, for: s1.file))
+        XCTAssertEqual(queue.existing[s1.file], .connection)
+
+        XCTAssertNoThrow(try queue.removeEvents(.connection, for: s1.file))
+        XCTAssertNil(queue.existing[s1.file])
+    }
+
+    func testRemovingEventToInvalidDescriptor_ThrowsError() throws {
+        let queue = try kQueue.make()
+
+        XCTAssertThrowsError(
+            try queue.removeEvent(.read, for: .validMock)
+        )
+    }
+
+    func testFilterEvents() {
+        XCTAssertEqual(
+            Socket.Event.read.kqueueFilter,
+            Int16(EVFILT_READ)
+        )
+        XCTAssertEqual(
+            Socket.Event.write.kqueueFilter,
+            Int16(EVFILT_WRITE)
+        )
+        XCTAssertEqual(
+            Socket.Event.make(from: Int16(EVFILT_READ)),
+            .read
+        )
+        XCTAssertEqual(
+            Socket.Event.make(from: Int16(EVFILT_WRITE)),
+            .write
+        )
+        XCTAssertNil(Socket.Event.make(from: 10100))
+    }
+
+    func testReadResult_CreatesNotification() {
+        XCTAssertEqual(
+            EventNotification.make(from: .make(
+                ident: 10,
+                filter: EVFILT_READ
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .read,
+                errors: []
+            )
+        )
+    }
+
+    func testReadErrors_CreatesNotification() {
+        XCTAssertEqual(
+            EventNotification.make(from: .make(
+                ident: 10,
+                filter: EVFILT_READ,
+                flags: EV_ERROR
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .read,
+                errors: [.error]
+            )
+        )
+    }
+
+    func testHUPErrorsIgnored_WhenRead() {
+        XCTAssertEqual(
+            EventNotification.make(from: .make(
+                ident: 10,
+                filter: EVFILT_READ,
+                flags: EV_EOF
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .read,
+                errors: []
+            )
+        )
+    }
+
+    func testWriteResult_CreatesNotification() {
+        XCTAssertEqual(
+            EventNotification.make(from: .make(
+                ident: 10,
+                filter: EVFILT_WRITE
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .write,
+                errors: []
+            )
+        )
+    }
+
+    func testWriteErrors_CreatesNotification() {
+        XCTAssertEqual(
+            EventNotification.make(from: .make(
+                ident: 10,
+                filter: EVFILT_WRITE,
+                flags: EV_EOF,
+                data: 10
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .write,
+                errors: [.endOfFile]
+            )
+        )
+    }
+
+    func testInvalidFilter_DoesNotCreateNotification() {
+        XCTAssertNil(
+            EventNotification.make(from: .make(
+                filter: 0
+            ))
+        )
+    }
+
+    func testQueueReturnsEvents() async throws {
+        var queue = try kQueue.make()
+
+        let (s1, s2) = try Socket.makeNonBlockingPair()
+
+        try queue.addEvents([.read], for: s2.file)
+
+        let data = Data([10, 20])
+        _ = try s1.write(data, from: data.startIndex)
+
+        await AsyncAssertEqual(
+            try await queue.getEvents(),
+            [.init(file: s2.file, events: [.read], errors: [])]
+        )
+    }
+
+    func testQueueThrowsErrorIfClosed() async throws {
+        var queue = try kQueue.make()
+        let (s1, _) = try Socket.makeNonBlockingPair()
+        try queue.addEvents([.read], for: s1.file)
+
+        try queue.reset()
+        await AsyncAssertThrowsError(try await queue.getEvents())
+    }
+}
+
+private extension kQueue {
+
+    static func make() throws -> Self {
+        var queue = kQueue()
+        try queue.prepare()
+        return queue
+    }
+
+    func getEvents() async throws -> [EventNotification] {
+        let queue = self
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global().async {
+                let result = Result {
+                    try queue.getNotifications(max: 10)
+                }
+                continuation.resume(with: result)
+            }
+        }
+    }
+}
+
+private extension kevent {
+    static func make(ident: UInt = 0,
+                     filter: Int32 = EVFILT_READ,
+                     flags: Int32 = 0,
+                     data: Int = 0) -> Self {
+        .init(ident: ident,
+              filter: Int16(filter),
+              flags: UInt16(flags),
+              fflags: 0,
+              data: data,
+              udata: nil)
+    }
+}
+#endif

--- a/FlyingSocks/Tests/EventQueueSocketPoolTests.swift
+++ b/FlyingSocks/Tests/EventQueueSocketPoolTests.swift
@@ -1,0 +1,299 @@
+//
+//  EventQueueSocketPoolTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 12/09/2022.
+//  Copyright © 2022 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingSocks
+import XCTest
+
+final class EventQueueSocketPoolTests: XCTestCase {
+
+    typealias Continuation = CancellingContinuation<Void, SocketError>
+    typealias Waiting = EventQueueSocketPool<MockEventQueue>.Waiting
+
+#if canImport(Darwin)
+    func testKqueuePool() {
+        let pool = makeEventQueuePool()
+        XCTAssertTrue(type(of: pool) == EventQueueSocketPool<kQueue>.self)
+    }
+#endif
+
+    func testQueuePrepare() async throws {
+        let pool = EventQueueSocketPool.make()
+
+        await AsyncAssertNil(await pool.state)
+
+        try await pool.prepare()
+        await AsyncAssertEqual(await pool.state, .ready)
+    }
+
+    func testQueueRun_ThrowsError_WhenNotReady() async throws {
+        let pool = EventQueueSocketPool.make()
+
+        await AsyncAssertThrowsError(try await pool.run(), of: Error.self)
+    }
+
+    func testSuspendedSockets_ThrowError_WhenCancelled() async throws {
+        let pool = EventQueueSocketPool.make()
+        try await pool.prepare()
+
+        let task = Task {
+            let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
+            try await pool.suspendSocket(socket, untilReadyFor: .read)
+        }
+
+        task.cancel()
+
+        await AsyncAssertThrowsError(try await task.value, of: CancellationError.self)
+    }
+
+    func testCancellingPollingPool_CancelsSuspendedSocket() async throws {
+        let pool = EventQueueSocketPool.make()
+        try await pool.prepare()
+
+        _ = Task(timeout: 0.5) {
+            try await pool.run()
+        }
+
+        let (s1, s2) = try Socket.makeNonBlockingPair()
+        await AsyncAssertThrowsError(
+            try await pool.suspendSocket(s1, untilReadyFor: .read),
+            of: CancellationError.self
+        )
+        try s1.close()
+        try s2.close()
+    }
+
+    func testCancellingPool_CancelsNewSockets() async throws {
+        let pool = EventQueueSocketPool.make()
+        try await pool.prepare()
+
+        let task = Task(timeout: 0.1) {
+            try await pool.run()
+        }
+
+        try? await task.value
+
+        let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
+        await AsyncAssertThrowsError(
+            try await pool.suspendSocket(socket, untilReadyFor: .read)
+        )
+    }
+
+    func testQueueNotification_ResumesSocket() async throws {
+        let pool = EventQueueSocketPool.make()
+        try await pool.prepare()
+        let task = Task { try await pool.run() }
+        defer { task.cancel() }
+
+        let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
+        let suspension = Task {
+            try await pool.suspendSocket(socket, untilReadyFor: .read)
+        }
+        defer { suspension.cancel() }
+
+        await pool.queue.sendResult(returning: [
+            .init(file: socket.file, events: .read, errors: [])
+        ])
+
+        await AsyncAssertNoThrow(
+            try await pool.suspendSocket(socket, untilReadyFor: .read)
+        )
+    }
+
+    func testQueueNotificationError_ResumesSocket_WithError() async throws {
+        let pool = EventQueueSocketPool.make()
+        try await pool.prepare()
+        let task = Task { try await pool.run() }
+        defer { task.cancel() }
+
+        let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
+        let suspension = Task {
+            try await pool.suspendSocket(socket, untilReadyFor: .read)
+        }
+        defer { suspension.cancel() }
+
+        await pool.queue.sendResult(returning: [
+            .init(file: socket.file, events: .read, errors: [.endOfFile])
+        ])
+
+        await AsyncAssertThrowsError(
+            try await pool.suspendSocket(socket, untilReadyFor: .read),
+            of: SocketError.self
+        ) { XCTAssertEqual($0, .disconnected) }
+    }
+
+    func testWaiting_IsEmpty() {
+        let cn = Continuation()
+
+        var waiting = Waiting()
+        XCTAssertTrue(waiting.isEmpty)
+
+        _ = waiting.appendContinuation(cn, for: .validMock, events: .read)
+        XCTAssertFalse(waiting.isEmpty)
+
+        _ = waiting.removeContinuation(cn, for: .validMock)
+        XCTAssertTrue(waiting.isEmpty)
+    }
+
+    func testWaitingEvents() {
+        var waiting = Waiting()
+        let cnRead = Continuation()
+        let cnRead1 = Continuation()
+        let cnWrite = Continuation()
+
+        XCTAssertEqual(
+            waiting.appendContinuation(cnRead, for: .validMock, events: .read),
+            [.read]
+        )
+        XCTAssertEqual(
+            waiting.appendContinuation(cnRead1, for: .validMock, events: .read),
+            [.read]
+        )
+        XCTAssertEqual(
+            waiting.appendContinuation(cnWrite, for: .validMock, events: .write),
+            [.read, .write]
+        )
+        XCTAssertEqual(
+            waiting.removeContinuation(.init(), for: .validMock),
+            []
+        )
+        XCTAssertEqual(
+            waiting.removeContinuation(cnWrite, for: .validMock),
+            [.write]
+        )
+        XCTAssertEqual(
+            waiting.removeContinuation(cnRead, for: .validMock),
+            []
+        )
+        XCTAssertEqual(
+            waiting.removeContinuation(cnRead1, for: .validMock),
+            [.read]
+        )
+    }
+
+    func testWaitingContinuations() {
+        var waiting = Waiting()
+        let cnRead = Continuation()
+        let cnRead1 = Continuation()
+        let cnWrite = Continuation()
+
+        _ = waiting.appendContinuation(cnRead, for: .validMock, events: .read)
+        _ = waiting.appendContinuation(cnRead1, for: .validMock, events: .read)
+        _ = waiting.appendContinuation(cnWrite, for: .validMock, events: .write)
+
+        XCTAssertEqual(
+            Set(waiting.continuations(for: .validMock, events: .read)),
+            [cnRead1, cnRead]
+        )
+        XCTAssertEqual(
+            Set(waiting.continuations(for: .validMock, events: .write)),
+            [cnWrite]
+        )
+        XCTAssertEqual(
+            Set(waiting.continuations(for: .validMock, events: .connection)),
+            [cnRead1, cnRead, cnWrite]
+        )
+        XCTAssertEqual(
+            Set(waiting.continuations(for: .validMock, events: [])),
+            []
+        )
+        XCTAssertEqual(
+            Set(waiting.continuations(for: .invalid, events: .connection)),
+            []
+        )
+    }
+}
+
+private extension EventQueueSocketPool where Queue == MockEventQueue  {
+    static func make() -> Self {
+        .init(queue: MockEventQueue())
+    }
+}
+
+final class MockEventQueue: EventQueue {
+
+    private var isWaiting: Bool = false
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var result: Result<[EventNotification], Error>?
+
+    private(set) var state: State?
+
+    enum State {
+        case prepared
+        case reset
+    }
+
+    func sendResult(returning success: [EventNotification]) {
+        result = .success(success)
+        if isWaiting {
+            semaphore.signal()
+        }
+    }
+
+    func sendResult(throwing error: Error) {
+        result = .failure(error)
+        if isWaiting {
+            semaphore.signal()
+        }
+    }
+
+    func addEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {
+
+    }
+
+    func removeEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {
+
+    }
+
+    func prepare() throws {
+        state = .prepared
+    }
+
+    func reset() throws {
+        state = .reset
+        result = .failure(CancellationError())
+        if isWaiting {
+            semaphore.signal()
+        }
+    }
+
+    func getNotifications(max count: Int32) throws -> [EventNotification] {
+        defer {
+            result = nil
+        }
+        if let result = result {
+            return try result.get()
+        } else {
+            isWaiting = true
+            semaphore.wait()
+            return try result!.get()
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `EventQueueSocketPool<Queue>` implementation allowing sockets to be monitored via kernel events.

This PR adds support for [`kqueue(2)`](https://www.freebsd.org/cgi/man.cgi?kqueue) on Darwin platforms. [`epoll(7)`](https://man7.org/linux/man-pages/man7/epoll.7.html) support will be added in the future.

`PollingSocketPool` remains the default pool used, but `HTTPServer` can be constructed with an event queue on Darwin:
```swift
let server = HTTPServer(port: 80, pool: makeEventQueuePool())
```

Event queues remove the need to continuously poll the awaiting file descriptors, instead a [DispatchQueue](https://developer.apple.com/documentation/dispatch/dispatchqueue) is used to wait indefinitely for any events to be returned from the queue.  Newly added file descriptors can be added and events will be returned to the already awaiting dispatch queue:

```
┌──────────────┐                        
│EventQueuePool│                        
└──────────────┘                ┌──────┐
       █                        │kqueue│
       █                        └──────┘
       █ prepare()                 █    
       █ ────────────────────────▶ █    
       █                           █    
       █                           █    
       █                           █    
       █                           █    
       █                           █    
       █                           █    
       █        ┌─────────────┐    █    
       █        │DispatchQueue│    █    
       █        └─────────────┘    █    
       █               █           █    
       █ getEvents()   █           █    
       █ ────────────▶ █           █    
       █               █ ────────▶ █    
       █               █           █    
       █                           █    
       █ addSocket(fd1)            █    
       █ ────────────────────────▶ █    
       █                           █    
       █               █           █    
       █               █ fd1 ready █    
       █               █ ◀──────── █    
       █   fd1 ready   █           █    
       █  ◀─────────── █           █    
       █                           █    
       █ removeSocket(fd1)         █    
       █ ────────────────────────▶ █    
       █                           █    
       █               █           █    
       █ getEvents()   █           █    
       █ ────────────▶ █           █    
       █               █           █    
       █               █           █    
```


