### PR TITLE
POLL Queue

### DIFF
--- a/FlyingSocks/Sources/EventQueue+Poll.swift
+++ b/FlyingSocks/Sources/EventQueue+Poll.swift
@@ -1,0 +1,201 @@
+//
+//  EventQueue+Poll.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 24/09/2022.
+//  Copyright © 2022 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+struct Poll: EventQueue {
+
+    private(set) var entries: Set<Entry>
+    private var isReady: Bool = false
+    private let interval: Interval
+
+    struct Entry: Hashable {
+        var file: Socket.FileDescriptor
+        var events: Socket.Events
+    }
+
+    enum Interval: Sendable {
+        case immediate
+        case seconds(TimeInterval)
+    }
+
+    init(interval: Interval) {
+        self.entries = []
+        self.interval = interval
+    }
+
+    mutating func reset() {
+        entries = []
+        isReady = false
+    }
+
+    mutating func prepare() {
+        entries = []
+        isReady = true
+    }
+
+    mutating func addEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {
+        guard isReady else { throw SocketError.makeFailed("poll.addEvents notReady") }
+        let entry = Entry(file: socket, events: events)
+        entries.insert(entry)
+    }
+
+    mutating func removeEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {
+        guard isReady else { throw SocketError.makeFailed("poll.removeEvents notReady") }
+        let entry = Entry(file: socket, events: events)
+        entries.remove(entry)
+    }
+
+    func getNotifications() throws -> [EventNotification] {
+        guard isReady else { throw SocketError.makeFailed("poll.getNotifications notReady") }
+        var buffer = entries.map(\.pollfd)
+
+        let status = Socket.poll(&buffer, UInt32(buffer.count), interval.milliseconds)
+        guard status > -1 else {
+            throw SocketError.makeFailed("poll.getNotifications poll")
+        }
+
+        return buffer.compactMap(EventNotification.make)
+    }
+}
+
+extension Poll.Entry {
+    var pollfd: pollfd {
+        Socket.pollfd(fd: file.rawValue,
+                      events: Int16(events.pollEvents.rawValue),
+                      revents: 0)
+    }
+}
+
+extension EventNotification {
+
+    static func make(from poll: pollfd) -> Self? {
+        let events = POLLEvents(poll.events)
+        let revents = POLLEvents(poll.revents)
+        let errors = Set<EventNotification.Error>.make(from: revents)
+
+        if events.contains(.write) && !errors.isEmpty {
+            return EventNotification(
+                file: .init(rawValue: poll.fd),
+                events: .init(events),
+                errors: errors
+            )
+        }
+
+        guard events.intersects(with: revents) else {
+            return nil
+        }
+
+        let notification = EventNotification(
+            file: .init(rawValue: poll.fd),
+            events: .init(revents),
+            errors: []
+        )
+
+        return notification
+    }
+}
+
+extension Poll.Interval {
+    var milliseconds: Int32 {
+        switch self {
+        case .immediate:
+            return 0
+        case .seconds(let seconds):
+            return Int32(seconds * 1000)
+        }
+    }
+}
+
+private struct POLLEvents: OptionSet, Hashable {
+    var rawValue: Int32
+
+    static let read = POLLEvents(rawValue: POLLIN)
+    static let write = POLLEvents(rawValue: POLLOUT)
+    static let err = POLLEvents(rawValue: POLLERR)
+    static let hup = POLLEvents(rawValue: POLLHUP)
+    static let nval = POLLEvents(rawValue: POLLNVAL)
+
+    static let errors: POLLEvents = [.err, .hup, .nval]
+
+    func intersects(with events: POLLEvents) -> Bool {
+        !intersection(events).isEmpty
+    }
+
+    init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    init(_ events: Int16) {
+        self.rawValue = Int32(events)
+    }
+}
+
+private extension Socket.Event {
+    var pollEvents: POLLEvents {
+        switch self {
+        case .read:
+            return .read
+        case .write:
+            return .write
+        }
+    }
+}
+
+private extension Socket.Events {
+    var pollEvents: POLLEvents {
+        reduce(POLLEvents()) { [$0, $1.pollEvents] }
+    }
+
+    init(_ events: POLLEvents) {
+        self = []
+        if events.contains(.read) {
+            self.insert(.read)
+        }
+        if events.contains(.write) {
+            self.insert(.write)
+        }
+    }
+}
+
+private extension Set where Element == EventNotification.Error {
+
+    static func make(from revents: POLLEvents) -> Self {
+        var errors = Set<EventNotification.Error>()
+        if revents.contains(.hup) {
+            errors.insert(.endOfFile)
+        }
+        if revents.contains(.nval) || revents.contains(.err) {
+            errors.insert(.error)
+        }
+        return errors
+    }
+}

--- a/FlyingSocks/Tests/EventQueue+PollTests.swift
+++ b/FlyingSocks/Tests/EventQueue+PollTests.swift
@@ -1,0 +1,250 @@
+//
+//  EventQueue+PollTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 25/09/2022.
+//  Copyright © 2022 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingSocks
+import XCTest
+
+final class PollTests: XCTestCase {
+
+    func testInterval() {
+        XCTAssertEqual(
+            Poll.Interval.immediate.milliseconds,
+            0
+        )
+
+        XCTAssertEqual(
+            Poll.Interval.seconds(1).milliseconds,
+            1000
+        )
+    }
+
+    func testAddingAndRemovingEvents() throws {
+        var queue = Poll.make()
+
+        XCTAssertNoThrow(try queue.addEvents(.connection, for: .validMock))
+        XCTAssertEqual(queue.entries, [.init(file: .validMock, events: .connection)])
+
+        XCTAssertNoThrow(try queue.removeEvents(.connection, for: .validMock))
+        XCTAssertEqual(queue.entries, [])
+    }
+
+    func testAddingEventWhenNotReady_ThrowsError() {
+        var queue = Poll.make()
+        queue.reset()
+
+        XCTAssertThrowsError(
+            try queue.addEvents(.read, for: .validMock)
+        )
+    }
+
+    func testRemovingEventWhenNotReady_ThrowsError() {
+        var queue = Poll.make()
+        queue.reset()
+
+        XCTAssertThrowsError(
+            try queue.removeEvents(.read, for: .validMock)
+        )
+    }
+
+    func testReadEntry_CreatesPollFD() {
+        let entry = Poll.Entry(file: .init(rawValue: 10), events: .read)
+
+        XCTAssertEqual(entry.pollfd.fd, 10)
+        XCTAssertEqual(entry.pollfd.events, Int16(POLLIN))
+        XCTAssertEqual(entry.pollfd.revents, 0)
+    }
+
+    func testWriteEntry_CreatesPollFD() {
+        let entry = Poll.Entry(file: .init(rawValue: 20), events: .write)
+
+        XCTAssertEqual(entry.pollfd.fd, 20)
+        XCTAssertEqual(entry.pollfd.events, Int16(POLLOUT))
+        XCTAssertEqual(entry.pollfd.revents, 0)
+    }
+
+    func testConnectionEntry_CreatesPollFD() {
+        let entry = Poll.Entry(file: .init(rawValue: 30), events: .connection)
+
+        XCTAssertEqual(entry.pollfd.fd, 30)
+        XCTAssertEqual(entry.pollfd.events, Int16(POLLOUT | POLLIN))
+        XCTAssertEqual(entry.pollfd.revents, 0)
+    }
+
+    func testReadResult_CreatesNotification() {
+        XCTAssertEqual(
+            EventNotification.make(from: pollfd.make(
+                fd: 10,
+                events: POLLIN,
+                revents: POLLIN
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .read,
+                errors: []
+            )
+        )
+    }
+
+    func testErrorsIgnored_WhenReadWithDataAvailable() {
+        XCTAssertEqual(
+            EventNotification.make(from: pollfd.make(
+                fd: 10,
+                events: POLLIN,
+                revents: POLLIN | POLLHUP
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .read,
+                errors: []
+            )
+        )
+    }
+
+    func testWriteResult_CreatesNotification() {
+        XCTAssertEqual(
+            EventNotification.make(from: pollfd.make(
+                fd: 10,
+                events: POLLOUT,
+                revents: POLLOUT
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .write,
+                errors: []
+            )
+        )
+    }
+
+    func testWriteHUP_CreatesNotification() {
+        XCTAssertEqual(
+            EventNotification.make(from: pollfd.make(
+                fd: 10,
+                events: POLLIN | POLLOUT,
+                revents: POLLHUP
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .connection,
+                errors: [.endOfFile]
+            )
+        )
+    }
+
+    func testWriteErrors_CreatesNotification() {
+        XCTAssertEqual(
+            EventNotification.make(from: pollfd.make(
+                fd: 10,
+                events: POLLOUT,
+                revents: POLLERR
+            )),
+            EventNotification(
+                file: .init(rawValue: 10),
+                events: .write,
+                errors: [.error]
+            )
+        )
+    }
+
+    func testUnmatchedRevents_DoesNotCreateNotification() {
+        XCTAssertNil(
+            EventNotification.make(from: pollfd.make(
+                events: POLLIN,
+                revents: 0
+            ))
+        )
+        XCTAssertNil(
+            EventNotification.make(from: pollfd.make(
+                events: POLLIN,
+                revents: POLLOUT
+            ))
+        )
+        XCTAssertNil(
+            EventNotification.make(from: pollfd.make(
+                events: POLLIN | POLLOUT,
+                revents: 0
+            ))
+        )
+    }
+
+    func testGetEvents_ReturnsEvents() async throws {
+        var queue = Poll.make()
+
+        let (s1, s2) = try Socket.makeNonBlockingPair()
+
+        try queue.addEvents([.read], for: s2.file)
+
+        let data = Data([10, 20])
+        _ = try s1.write(data, from: data.startIndex)
+
+        await AsyncAssertEqual(
+            try await queue.getEvents(),
+            [.init(file: s2.file, events: [.read], errors: [])]
+        )
+    }
+
+    func testGetEventsWhenNotReady_ThrowsError() async {
+        var queue = Poll.make()
+        queue.reset()
+
+        await AsyncAssertThrowsError(
+            try await queue.getEvents()
+        )
+    }
+}
+
+private extension Poll {
+
+    static func make() -> Self {
+        var queue = Poll(interval: .immediate)
+        queue.prepare()
+        return queue
+    }
+
+    func getEvents() async throws -> [EventNotification] {
+        let queue = self
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global().async {
+                let result = Result {
+                    try queue.getNotifications()
+                }
+                continuation.resume(with: result)
+            }
+        }
+    }
+}
+
+private extension pollfd {
+    static func make(fd: Int32 = 0,
+                     events: Int32 = POLLIN,
+                     revents: Int32 = POLLIN) -> Self {
+        .init(fd: fd, events: Int16(events), revents: Int16(revents))
+    }
+}

--- a/FlyingSocks/Tests/EventQueue+kQueueTests.swift
+++ b/FlyingSocks/Tests/EventQueue+kQueueTests.swift
@@ -207,7 +207,7 @@ final class kQueueTests: XCTestCase {
 private extension kQueue {
 
     static func make() throws -> Self {
-        var queue = kQueue()
+        var queue = kQueue(maxEvents: 20)
         try queue.prepare()
         return queue
     }
@@ -217,7 +217,7 @@ private extension kQueue {
         return try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global().async {
                 let result = Result {
-                    try queue.getNotifications(max: 10)
+                    try queue.getNotifications()
                 }
                 continuation.resume(with: result)
             }

--- a/FlyingSocks/Tests/EventQueueSocketPoolTests.swift
+++ b/FlyingSocks/Tests/EventQueueSocketPoolTests.swift
@@ -233,7 +233,7 @@ final class EventQueueSocketPoolTests: XCTestCase {
 
 private extension EventQueueSocketPool where Queue == MockEventQueue  {
     static func make() -> Self {
-        .init(queue: MockEventQueue(), maxEvents: 5)
+        .init(queue: MockEventQueue())
     }
 }
 
@@ -284,7 +284,7 @@ final class MockEventQueue: EventQueue {
         }
     }
 
-    func getNotifications(max count: Int32) throws -> [EventNotification] {
+    func getNotifications() throws -> [EventNotification] {
         defer {
             result = nil
         }


### PR DESCRIPTION
Adds [`poll(2)`](https://www.freebsd.org/cgi/man.cgi?poll) implementation of `protocol EventQueue` allowing `EventQueueSocketPool<Poll>` to replace `PollingSocketPool`.

Allows all platforms to construct an `EventQueueSocketPool<Queue>` with `makeEventQueuePool()`
- Darwin `EventQueueSocketPool<kQueue>`
- Linux `EventQueueSocketPool<ePoll>`
- Windows / Darwin / Linux `EventQueueSocketPool<Poll>`
