### PR TITLE
ClientPoolLoader

### DIFF
--- a/FlyingFox/Tests/AsyncSocketTests.swift
+++ b/FlyingFox/Tests/AsyncSocketTests.swift
@@ -35,12 +35,20 @@ import Foundation
 
 extension AsyncSocket {
 
-    static func make(pool: AsyncSocketPool = .pollingClient) throws -> AsyncSocket {
+    static func make() async throws -> AsyncSocket {
+        try await make(pool: .client)
+    }
+
+    static func make(pool: AsyncSocketPool) throws -> AsyncSocket {
         let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
         return try AsyncSocket(socket: socket, pool: pool)
     }
 
-    static func makePair(pool: AsyncSocketPool = .pollingClient) throws -> (AsyncSocket, AsyncSocket) {
+    static func makePair() async throws -> (AsyncSocket, AsyncSocket) {
+        try await makePair(pool: .client)
+    }
+
+    static func makePair(pool: AsyncSocketPool) throws -> (AsyncSocket, AsyncSocket) {
         let (file1, file2) = Socket.socketpair(AF_UNIX, Socket.stream, 0)
         guard file1.rawValue > -1, file2.rawValue > -1 else {
             throw SocketError.makeFailed("SocketPair")

--- a/FlyingFox/Tests/HTTPConnectionTests.swift
+++ b/FlyingFox/Tests/HTTPConnectionTests.swift
@@ -40,7 +40,7 @@ import FoundationNetworking
 final class HTTPConnectionTests: XCTestCase {
 
     func testConnection_ReceivesRequest() async throws {
-        let (s1, s2) = try AsyncSocket.makePair()
+        let (s1, s2) = try await AsyncSocket.makePair()
 
         let connection = HTTPConnection(socket: s1)
         try await s2.writeString(
@@ -68,7 +68,7 @@ final class HTTPConnectionTests: XCTestCase {
     }
 
     func testConnectionRequestsAreReceived_WhileConnectionIsKeptAlive() async throws {
-        let (s1, s2) = try AsyncSocket.makePair()
+        let (s1, s2) = try await AsyncSocket.makePair()
 
         let connection = HTTPConnection(socket: s1)
         try await s2.writeString(
@@ -93,7 +93,7 @@ final class HTTPConnectionTests: XCTestCase {
     }
 
     func testConnectionResponse_IsSent() async throws {
-        let (s1, s2) = try AsyncSocket.makePair()
+        let (s1, s2) = try await AsyncSocket.makePair()
 
         let connection = HTTPConnection(socket: s1)
 
@@ -115,7 +115,7 @@ final class HTTPConnectionTests: XCTestCase {
     }
 
     func testConnectionDisconnects_WhenErrorIsReceived() async throws {
-        let (s1, s2) = try AsyncSocket.makePair()
+        let (s1, s2) = try await AsyncSocket.makePair()
 
         try s2.close()
         let connection = HTTPConnection(socket: s1)

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -154,7 +154,7 @@ final class HTTPServerTests: XCTestCase {
         await server.appendRoute("GET /socket", to: .webSocket(EchoWSMessageHandler()))
         try await startServer(server)
 
-        let socket = try await AsyncSocket.connected(to: address, pool: SleepingPool())
+        let socket = try await AsyncSocket.connected(to: address)
         defer { try? socket.close() }
 
         var request = HTTPRequest.make(path: "/socket")
@@ -196,7 +196,7 @@ final class HTTPServerTests: XCTestCase {
         }
         try await startServer(server)
 
-        let socket = try await AsyncSocket.connected(to: address, pool: SleepingPool())
+        let socket = try await AsyncSocket.connected(to: address)
         defer { try? socket.close() }
         try await socket.writeRequest(.make())
 
@@ -213,7 +213,7 @@ final class HTTPServerTests: XCTestCase {
         }
         let port = try await startServerWithPort(server)
 
-        let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: port), pool: SleepingPool())
+        let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: port))
         defer { try? socket.close() }
 
         try await socket.writeRequest(.make())
@@ -231,7 +231,7 @@ final class HTTPServerTests: XCTestCase {
             return .make(statusCode: .ok)
         }
         let port = try await startServerWithPort(server)
-        let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: port), pool: SleepingPool())
+        let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: port))
         defer { try? socket.close() }
 
         try await socket.writeRequest(.make())
@@ -249,7 +249,7 @@ final class HTTPServerTests: XCTestCase {
         let server = HTTPServer.make(logger: HTTPServer.defaultLogger())
 
         let port = try await startServerWithPort(server)
-        let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: port), pool: SleepingPool())
+        let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: port))
         defer { try? socket.close() }
 
         try await Task.sleep(seconds: 0.5)
@@ -410,14 +410,5 @@ extension URLSessionWebSocketTask.Message: Equatable {
 extension Task where Success == Never, Failure == Never {
     static func sleep(seconds: TimeInterval) async throws {
         try await sleep(nanoseconds: UInt64(1_000_000_000 * seconds))
-    }
-}
-
-private struct SleepingPool: AsyncSocketPool {
-    func prepare() async throws { }
-    func run() async throws { }
-
-    func suspendSocket(_ socket: Socket, untilReadyFor events: Socket.Events) async throws {
-        try await Task.sleep(seconds: 0.1)
     }
 }

--- a/FlyingSocks/Sources/PollingSocketPool.swift
+++ b/FlyingSocks/Sources/PollingSocketPool.swift
@@ -46,25 +46,4 @@ public extension SocketPool where Queue == Poll {
         self.init(queue: Poll(interval: pollInterval))
     }
 #endif
-
-#if compiler(>=5.7)
-    static let client: SocketPool<some EventQueue> = {
-        let pool = SocketPool.make()
-        Task {
-            try await pool.prepare()
-            try await pool.run()
-        }
-        return pool
-    }()
-#else
-    static let client: SocketPool<Poll> = {
-        let pool = SocketPool(queue: Poll(interval: .seconds(0.01)))
-        Task {
-            try await pool.prepare()
-            try await pool.run()
-        }
-        return pool
-    }()
-#endif
-
 }

--- a/FlyingSocks/Sources/SocketPool.swift
+++ b/FlyingSocks/Sources/SocketPool.swift
@@ -57,10 +57,9 @@ public func makeEventQueuePool(maxEvents limit: Int = 20) -> AsyncSocketPool {
     fatalError("init pool directly")
 }
 
-#if compiler(>=5.7)
 public extension AsyncSocketPool where Self == SocketPool<Poll> {
 
-    static func make(maxEvents limit: Int = 20, logger: Logging? = nil) -> SocketPool<some EventQueue> {
+    static func make(maxEvents limit: Int = 20, logger: Logging? = nil) -> some AsyncSocketPool {
     #if canImport(Darwin)
         return .kQueue(maxEvents: limit, logger: logger)
     #elseif canImport(CSystemLinux)
@@ -70,7 +69,6 @@ public extension AsyncSocketPool where Self == SocketPool<Poll> {
     #endif
     }
 }
-#endif
 
 public final actor SocketPool<Queue: EventQueue>: AsyncSocketPool {
 


### PR DESCRIPTION
replaces `.pollingClient: AsyncSocketPool` with `.client: some AsyncSocketPool { get async throws }` enabling a the shared pool to be managed by `ClientPoolLoader` and clients can now wait for the pool to be prepared before attempting to use it.