### PR TITLE
Add support for text/css within FileHTTPHandler

### DIFF
--- a/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
@@ -55,6 +55,8 @@ public struct FileHTTPHandler: HTTPHandler {
             return "application/json"
         case "html", "htm":
             return "text/html"
+        case "css":
+            return "text/css"
         case "js", "javascript":
             return "application/javascript"
         case "png":

--- a/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
@@ -111,6 +111,10 @@ final class HTTPHandlerTests: XCTestCase {
             "text/html"
         )
         XCTAssertEqual(
+            FileHTTPHandler.makeContentType(for: "fish.css"),
+            "text/css"
+        )
+        XCTAssertEqual(
             FileHTTPHandler.makeContentType(for: "fish.js"),
             "application/javascript"
         )


### PR DESCRIPTION
Adds automatic support for `Content-Type: text/css` when file extension is `.css`

https://github.com/swhitty/FlyingFox/issues/52