### PR TITLE
HTTPBodySequence to enable very large requests

### DIFF
--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -1,0 +1,126 @@
+//
+//  HTTPBodySequence.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 02/04/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import FlyingSocks
+@_spi(Private) import struct FlyingSocks.AsyncDataSequence
+
+public struct HTTPBodySequence: Sendable, AsyncSequence {
+    public typealias Element = Data
+
+    let storage: Storage
+
+    public init() {
+        self.storage = .complete(Data())
+    }
+
+    public init(data: Data) {
+        self.storage = .complete(data)
+    }
+
+    public init<S: AsyncChunkedSequence>(from bytes: S, count: Int, chunkSize: Int) where S.Element == UInt8 {
+        self.storage = .sequence(AsyncDataSequence(from: bytes, count: count, chunkSize: chunkSize))
+    }
+
+    public func makeAsyncIterator() -> Iterator {
+        Iterator(storage: storage)
+    }
+
+    enum Storage: @unchecked Sendable {
+        case complete(Data)
+        case sequence(AsyncDataSequence)
+    }
+
+    public var count: Int {
+        switch storage {
+        case .complete(let data):
+            return data.count
+        case .sequence(let sequence):
+            return sequence.count
+        }
+    }
+
+    func get() async throws -> Data {
+        switch storage {
+        case .complete(let data):
+            return data
+        case .sequence(let sequence):
+            return try await sequence.reduce(into: Data()) {
+                $0.append($1)
+            }
+        }
+    }
+
+    func flushIfNeeded() async throws {
+        guard case .sequence(let sequence) = storage else { return }
+        try await sequence.flushIfNeeded()
+    }
+}
+
+public extension HTTPBodySequence {
+
+    struct Iterator: AsyncIteratorProtocol {
+        public typealias Element = Data
+
+        private var storage: Internal
+        private var isComplete: Bool = false
+
+        fileprivate init(storage: Storage) {
+            switch storage {
+            case .complete(let data):
+                self.storage = .complete(data)
+            case .sequence(let sequence):
+                self.storage = .iterator(sequence.makeAsyncIterator())
+            }
+        }
+
+        public mutating func next() async throws -> Data? {
+            guard !isComplete else { return nil }
+            switch storage {
+            case let .complete(data):
+                isComplete = true
+                return data
+            case var .iterator(iterator):
+                guard let result = try await iterator.next() else {
+                    isComplete = true
+                    return nil
+                }
+                storage = .iterator(iterator)
+                return result
+            }
+        }
+
+        enum Internal: @unchecked Sendable {
+            case complete(Data)
+            case iterator(AsyncDataSequence.AsyncIterator)
+        }
+    }
+}

--- a/FlyingFox/Sources/HTTPEncoder.swift
+++ b/FlyingFox/Sources/HTTPEncoder.swift
@@ -63,7 +63,7 @@ struct HTTPEncoder {
                       request.version.rawValue].joined(separator: " ")
 
         var httpHeaders = request.headers
-        httpHeaders[.contentLength] = String(request.payload.count)
+        httpHeaders[.contentLength] = String(request.bodySequence.count)
         let headers = httpHeaders.map { "\($0.key.rawValue): \($0.value)" }
 
         return [status] + headers + ["\r\n"]
@@ -79,12 +79,12 @@ struct HTTPEncoder {
         return "\(comps.percentEncodedPath)?\(query)"
     }
 
-    static func encodeRequest(_ request: HTTPRequest) throws -> Data {
+    static func encodeRequest(_ request: HTTPRequest) async throws -> Data {
         var data = makeHeaderLines(from: request)
             .joined(separator: "\r\n")
             .data(using: .utf8)!
 
-        data.append(request.payload)
+        try await data.append(request.bodyData)
 
         return data
     }

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -156,6 +156,7 @@ public final actor HTTPServer {
             for try await request in connection.requests {
                 logger?.logRequest(request, on: connection)
                 let response = await handleRequest(request)
+                try await request.bodySequence.flushIfNeeded()
                 try await connection.sendResponse(response)
             }
         } catch {

--- a/FlyingFox/Tests/HTTPBodySequenceTests.swift
+++ b/FlyingFox/Tests/HTTPBodySequenceTests.swift
@@ -1,0 +1,225 @@
+//
+//  HTTPBodySequenceTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 02/04/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingFox
+@_spi(Private) import struct FlyingSocks.AsyncDataSequence
+import XCTest
+
+final class HTTPBodySequenceTests: XCTestCase {
+
+    func testEmptyPayload_ReturnsEmptyData() async {
+        let sequence = HTTPBodySequence()
+
+        var iterator = sequence.makeAsyncIterator()
+
+        await AsyncAssertEqual(
+            try await iterator.next(),
+            Data()
+        )
+
+        await AsyncAssertNil(
+            try await iterator.next()
+        )
+    }
+
+    func testDataPayload_IsReturnedInOneIteration() async {
+        let sequence = HTTPBodySequence(bytes: [
+            0x00, 0x01, 0x02, 0x03, 0x04
+        ])
+
+        var iterator = sequence.makeAsyncIterator()
+
+        await AsyncAssertEqual(
+            try await iterator.next(),
+            Data([0x00, 0x01, 0x02, 0x03, 0x04])
+        )
+
+        await AsyncAssertNil(
+            try await iterator.next()
+        )
+    }
+
+    func testDataPayload_CanBeIteratedMultipleTimes() async {
+        let data = Data([
+            0x00, 0x01, 0x02
+        ])
+
+        let sequence = HTTPBodySequence(data: data)
+
+        await AsyncAssertEqual(
+            try await sequence.get(),
+            data
+        )
+
+        await AsyncAssertEqual(
+            try await sequence.get(),
+            data
+        )
+
+        await AsyncAssertEqual(
+            try await sequence.get(),
+            data
+        )
+    }
+
+    func testDataPayload_ReturnsCount() {
+        XCTAssertEqual(
+            HTTPBodySequence().count,
+            0
+        )
+        XCTAssertEqual(
+            HTTPBodySequence(bytes: [0x0]).count,
+            1
+        )
+        XCTAssertEqual(
+            HTTPBodySequence(bytes: [0x00, 0x01, 0x02, 0x03, 0x04]).count,
+            5
+        )
+    }
+
+    func testSequencePayload_ReturnsCount() {
+        XCTAssertEqual(
+            HTTPBodySequence.make(from: []).count,
+            0
+        )
+        XCTAssertEqual(
+            HTTPBodySequence.make(from: [0x0]).count,
+            1
+        )
+        XCTAssertEqual(
+            HTTPBodySequence.make(from: [0x00, 0x01, 0x02, 0x03, 0x04]).count,
+            5
+        )
+    }
+
+    func testSequencePayload_CanBeReturned() async {
+        let sequence = HTTPBodySequence.make(
+            from: [0x00, 0x01, 0x02, 0x03, 0x04],
+            chunkSize: 2
+        )
+
+        await AsyncAssertEqual(
+            try await sequence.get(),
+            Data([0x00, 0x01, 0x02, 0x03, 0x04])
+        )
+    }
+
+    func testSequencePayload_CanBeIterated() async {
+        let sequence = HTTPBodySequence.make(
+            from: [0x00, 0x01, 0x02, 0x03, 0x04],
+            chunkSize: 2
+        )
+
+        var iterator = sequence.makeAsyncIterator()
+
+        await AsyncAssertEqual(
+            try await iterator.next(),
+            Data([0x00, 0x01])
+        )
+
+        await AsyncAssertEqual(
+            try await iterator.next(),
+            Data([0x02, 0x03])
+        )
+
+        await AsyncAssertEqual(
+            try await iterator.next(),
+            Data([0x04])
+        )
+
+        await AsyncAssertNil(
+            try await iterator.next()
+        )
+    }
+
+    func testSequencePayload_CannotBeIteratedMultipleTimes() async {
+        let sequence = HTTPBodySequence.make(
+            from: [0x0, 0x1],
+            chunkSize: 1
+        )
+
+        var it1 = sequence.makeAsyncIterator()
+        var it2 = sequence.makeAsyncIterator()
+
+        await AsyncAssertEqual(
+            try await it1.next(),
+            Data([0x0])
+        )
+
+        await AsyncAssertThrowsError(
+            try await it2.next()
+        )
+
+        await AsyncAssertEqual(
+            try await it1.next(),
+            Data([0x1])
+        )
+
+        await AsyncAssertNil(
+            try await it1.next()
+        )
+    }
+
+    func testSequencePayload_IsFlushed() async {
+        // given
+        let buffer = ConsumingAsyncSequence<UInt8>(
+            [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
+        )
+
+        let sequence = HTTPBodySequence(from: buffer, count: 10, chunkSize: 2)
+
+        // then
+        XCTAssertEqual(buffer.index, 0)
+
+        // when
+        await AsyncAssertNoThrow(
+            try await sequence.flushIfNeeded()
+        )
+
+        // then
+        XCTAssertEqual(buffer.index, 10)
+    }
+}
+
+private extension HTTPBodySequence {
+
+    init(bytes: [UInt8]) {
+        self.init(data: Data(bytes))
+    }
+
+    static func make(from bytes: [UInt8], count: Int? = nil, chunkSize: Int = 2) -> Self {
+        HTTPBodySequence(
+            from: ConsumingAsyncSequence(bytes),
+            count: count ?? bytes.count,
+            chunkSize: chunkSize
+        )
+    }
+}

--- a/FlyingFox/Tests/HTTPConnectionTests.swift
+++ b/FlyingFox/Tests/HTTPConnectionTests.swift
@@ -39,6 +39,7 @@ import FoundationNetworking
 
 final class HTTPConnectionTests: XCTestCase {
 
+#if compiler(>=5.6)
     func testConnection_ReceivesRequest() async throws {
         let (s1, s2) = try await AsyncSocket.makePair()
 
@@ -66,6 +67,7 @@ final class HTTPConnectionTests: XCTestCase {
         try s1.close()
         try s2.close()
     }
+#endif
 
     func testConnectionRequestsAreReceived_WhileConnectionIsKeptAlive() async throws {
         let (s1, s2) = try await AsyncSocket.makePair()
@@ -157,8 +159,9 @@ extension AsyncSequence {
     }
 }
 
+#if compiler(>=5.6)
 extension HTTPRequest: AsyncEquatable {
-    static func == (lhs: HTTPRequest, rhs: HTTPRequest) async -> Bool {
+    static func ==(lhs: HTTPRequest, rhs: HTTPRequest) async -> Bool {
         guard (try? await lhs.bodyData == rhs.bodyData) == true else { return false }
         return lhs.method == rhs.method &&
                lhs.version == rhs.version &&
@@ -167,3 +170,4 @@ extension HTTPRequest: AsyncEquatable {
                lhs.headers == rhs.headers
     }
 }
+#endif

--- a/FlyingFox/Tests/HTTPEncoderTests.swift
+++ b/FlyingFox/Tests/HTTPEncoderTests.swift
@@ -122,9 +122,9 @@ final class HTTPEncoderTests: XCTestCase {
         )
     }
 
-    func testEncodesRequest() throws {
-        XCTAssertEqual(
-            try HTTPEncoder.encodeRequest(
+    func testEncodesRequest() async throws {
+        await AsyncAssertEqual(
+            try await HTTPEncoder.encodeRequest(
                 .make(method: .GET,
                       version: .http11,
                       path: "greeting/hello world",
@@ -141,9 +141,9 @@ final class HTTPEncoderTests: XCTestCase {
         )
     }
 
-    func testEncodesRequest_WithQuery() throws {
-        XCTAssertEqual(
-            try HTTPEncoder.encodeRequest(
+    func testEncodesRequest_WithQuery() async throws {
+        await AsyncAssertEqual(
+            try await HTTPEncoder.encodeRequest(
                 .make(method: .GET,
                       version: .http11,
                       path: "greeting/hello world",

--- a/FlyingFox/Tests/HTTPRequestTests.swift
+++ b/FlyingFox/Tests/HTTPRequestTests.swift
@@ -1,9 +1,9 @@
 //
-//  ConsumingAsyncSequence.swift
+//  HTTPRequestTests.swift
 //  FlyingFox
 //
-//  Created by Simon Whitty on 17/02/2022.
-//  Copyright © 2022 Simon Whitty. All rights reserved.
+//  Created by Simon Whitty on 02/04/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
 //
 //  Distributed under the permissive MIT license
 //  Get the latest version from here:
@@ -29,30 +29,28 @@
 //  SOFTWARE.
 //
 
-import FlyingSocks
+@testable import FlyingFox
+import XCTest
 
-final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, AsyncChunkedIteratorProtocol {
+final class HTTPRequestTests: XCTestCase {
 
-    private var iterator: AnySequence<Element>.Iterator
-    private(set) var index: Int = 0
+    func testRequestBodyData_CanBeChanged() async {
+        // when
+        var request = HTTPRequest.make(body: Data([0x01, 0x02]))
 
-    init<T: Sequence>(_ sequence: T) where T.Element == Element {
-        self.iterator = AnySequence(sequence).makeIterator()
-    }
+        // then
+        await AsyncAssertEqual(
+            try await request.bodyData,
+            Data([0x01, 0x02])
+        )
 
-    func makeAsyncIterator() -> ConsumingAsyncSequence<Element> { self }
+        // when
+        request.setBodyData(Data([0x05, 0x06]))
 
-    func next() async throws -> Element? {
-        iterator.next()
-    }
-
-    func nextChunk(count: Int) async throws -> [Element]? {
-        var buffer = [Element]()
-        while buffer.count < count,
-              let element = iterator.next() {
-            buffer.append(element)
-        }
-        index += buffer.count
-        return buffer.count == count ? buffer : nil
+        // then
+        await AsyncAssertEqual(
+            try await request.bodyData,
+            Data([0x05, 0x06])
+        )
     }
 }


### PR DESCRIPTION
In current versions ([0.10.0](https://github.com/swhitty/FlyingFox/releases/tag/0.10.0) and earlier) each `HTTPRequest` instance includes the entire request body within the `var body: Data` property limiting the size of requests that can be processed.

### HTTPBodySequence
This PR introduces `HTTPBodySequence` that can represent the body of requests as an `AsyncSequence` of `Data` elements allowing request handlers to process the body in chunks as it is uploaded:

```swift
func saveBody(request: HTTPRequest) async throws -> HTTPResponse {
  let file =  URL(fileURLWithPath: "/tmp/file")
  _ = FileManager.default.createFile(atPath: file.path, contents: nil)
  let handle = try FileHandle(forWritingTo: file)
  defer { try? handle.close() }
  for try await chunk in req.bodySequence {
    try handle.write(contentsOf: chunk)
  }
}
```
> Note: Large bodies > 10 megabytes in size can only be iterated one-time-only. Smaller body payloads can be iterated and processed multiple times.

### HTTPRequest
`HTTPRequest` still includes previous `var body: Data` property but it is now deprecated and replaced by:

```swift
var bodySequence: HTTPBodySequence

var bodyData: Data { get async throws }

// deprecated, use `bodyData` instead
var body: Data
```

While `var body: Data` is marked as deprecated, it does will still return the request body synchronously — if the body is less than 10 megabytes in size.

