### PR TITLE
HTTPBodySequence to enable very large responses

### DIFF
--- a/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
@@ -71,13 +71,19 @@ public struct FileHTTPHandler: HTTPHandler {
     }
 
     public func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
-        guard let path = path,
-              let data = try? Data(contentsOf: path) else {
-                  return HTTPResponse(statusCode: .notFound)
-              }
+        guard let path = path else {
+            return HTTPResponse(statusCode: .notFound)
+        }
 
-        return HTTPResponse(statusCode: .ok,
-                            headers: [.contentType: contentType],
-                            body: data)
+        do {
+            return try HTTPResponse(
+                statusCode: .ok,
+                headers: [.contentType: contentType],
+                body: HTTPBodySequence(file: path)
+            )
+        } catch {
+            print("🔴", error)
+            return HTTPResponse(statusCode: .notFound)
+        }
     }
 }

--- a/FlyingFox/Tests/HTTPConnectionTests.swift
+++ b/FlyingFox/Tests/HTTPConnectionTests.swift
@@ -101,17 +101,18 @@ final class HTTPConnectionTests: XCTestCase {
 
         try await connection.sendResponse(
             .make(version: .http11,
-                  statusCode: .gone)
+                  statusCode: .gone,
+                  body: "Hello World!".data(using: .utf8)!)
         )
 
-        let response = try await s2.readString(length: 40)
+        let response = try await s2.readString(length: 53)
         XCTAssertEqual(
             response,
             """
             HTTP/1.1 410 Gone\r
-            Content-Length: 0\r
+            Content-Length: 12\r
             \r
-
+            Hello World!
             """
         )
     }

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -239,8 +239,8 @@ final class HTTPDecoderTests: XCTestCase {
             """
         )
 
-        XCTAssertEqual(
-            response.body,
+        await AsyncAssertEqual(
+            try await response.bodyData,
             Data()
         )
     }
@@ -255,8 +255,8 @@ final class HTTPDecoderTests: XCTestCase {
             """
         )
 
-        XCTAssertEqual(
-            response.body,
+        await AsyncAssertEqual(
+            try await response.bodyData,
             "Hello".data(using: .utf8)
         )
     }

--- a/FlyingFox/Tests/HTTPEncoderTests.swift
+++ b/FlyingFox/Tests/HTTPEncoderTests.swift
@@ -105,9 +105,9 @@ final class HTTPEncoderTests: XCTestCase {
         )
     }
 
-    func testEncodesResponse() throws {
+    func testEncodesResponseHeader() throws {
         XCTAssertEqual(
-            HTTPEncoder.encodeResponse(
+            HTTPEncoder.encodeResponseHeader(
                 .make(version: .http11,
                       statusCode: .ok,
                       headers: [:],
@@ -117,7 +117,7 @@ final class HTTPEncoderTests: XCTestCase {
             HTTP/1.1 200 OK\r
             Content-Length: 12\r
             \r
-            Hello World!
+
             """.data(using: .utf8)
         )
     }

--- a/FlyingFox/Tests/HTTPResponse+Mock.swift
+++ b/FlyingFox/Tests/HTTPResponse+Mock.swift
@@ -43,4 +43,20 @@ extension HTTPResponse {
                      headers: headers,
                      body: body)
     }
+
+    static func make(version: HTTPVersion = .http11,
+                     statusCode: HTTPStatusCode  = .ok,
+                     headers: [HTTPHeader: String] = [:],
+                     body: HTTPBodySequence) -> Self {
+        HTTPResponse(version: version,
+                     statusCode: statusCode,
+                     headers: headers,
+                     body: body)
+    }
+
+    static func make(headers: [HTTPHeader: String] = [:],
+                     webSocket handler: WSHandler) -> Self {
+        HTTPResponse(headers: headers,
+                     webSocket: handler)
+    }
 }

--- a/FlyingFox/Tests/HTTPResponseTests.swift
+++ b/FlyingFox/Tests/HTTPResponseTests.swift
@@ -32,85 +32,45 @@
 @testable import FlyingFox
 import XCTest
 
-final class HTTPResponseTests: XCTestCase {
+final class HTTPRequestTests: XCTestCase {
 
-    func testCompleteBodyData() async {
-        // given
-        let response = HTTPResponse.make(body: Data([0x01, 0x02]))
-
-        // then
-        await AsyncAssertEqual(
-            try await response.bodyData,
-            Data([0x01, 0x02])
-        )
-    }
-
-    func testSequenceBodyData() async {
-        // given
-        let buffer = ConsumingAsyncSequence<UInt8>(
-            [0x5, 0x6]
-        )
-        let sequence = HTTPBodySequence(from: buffer, count: 2, chunkSize: 2)
-        let response = HTTPResponse.make(body: sequence)
+    func testRequestBodyData_CanBeChanged() async {
+        // when
+        var request = HTTPRequest.make(body: Data([0x01, 0x02]))
 
         // then
         await AsyncAssertEqual(
-            try await response.bodyData,
-            Data([0x5, 0x6])
-        )
-    }
-
-    func testWebSocketBodyData() async {
-        // given
-        let response = HTTPResponse.make(webSocket: MessageFrameWSHandler.make())
-
-        // then
-        await AsyncAssertNil(
-            try await response.bodyData
-        )
-    }
-
-    func testDeprecatedBodyProperty_Complete() {
-        // given
-        var response = HTTPResponse.make(body: Data([0x01, 0x02]))
-
-        // then
-        XCTAssertEqual(
-            response.body,
+            try await request.bodyData,
             Data([0x01, 0x02])
         )
 
         // when
-        response.payload = .body(Data([0x04, 0x05]))
+        request.setBodyData(Data([0x05, 0x06]))
+
+        // then
+        await AsyncAssertEqual(
+            try await request.bodyData,
+            Data([0x05, 0x06])
+        )
+    }
+
+    func testDeprecatedBodyProperty() {
+        // when
+        var request = HTTPRequest.make(body: Data([0x01, 0x02]))
 
         // then
         XCTAssertEqual(
-            response.body,
+            request.body,
+            Data([0x01, 0x02])
+        )
+
+        // when
+        request.body = Data([0x04, 0x05])
+
+        // then
+        XCTAssertEqual(
+            request.body,
             Data([0x04, 0x05])
-        )
-    }
-
-    func testDeprecatedBodyProperty_Sequence() {
-        // given
-        let buffer = ConsumingAsyncSequence<UInt8>(
-            [0x5, 0x6]
-        )
-        let sequence = HTTPBodySequence(from: buffer, count: 2, chunkSize: 2)
-        let response = HTTPResponse.make(body: sequence)
-
-        // then
-        XCTAssertNil(
-            response.body
-        )
-    }
-
-    func testDeprecatedBodyProperty_WebSocket() {
-        // given
-        let response = HTTPResponse.make(webSocket: MessageFrameWSHandler.make())
-
-        // then
-        XCTAssertNil(
-            response.body
         )
     }
 }

--- a/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
@@ -40,7 +40,10 @@ final class DirectoryHTTPHandlerTests: XCTestCase {
         let response = try await handler.handleRequest(.make(path: "server/path/fish.json"))
         XCTAssertEqual(response.statusCode, .ok)
         XCTAssertEqual(response.headers[.contentType], "application/json")
-        XCTAssertEqual(response.body, #"{"fish": "cakes"}"#.data(using: .utf8))
+        await AsyncAssertEqual(
+            try await response.bodyData,
+            #"{"fish": "cakes"}"#.data(using: .utf8)
+        )
     }
 
     func testDirectoryHandler_PlainInitialiser_ReturnsFile() async throws {
@@ -50,7 +53,10 @@ final class DirectoryHTTPHandlerTests: XCTestCase {
         let response = try await handler.handleRequest(.make(path: "server/path/fish.json"))
         XCTAssertEqual(response.statusCode, .ok)
         XCTAssertEqual(response.headers[.contentType], "application/json")
-        XCTAssertEqual(response.body, #"{"fish": "cakes"}"#.data(using: .utf8))
+        await AsyncAssertEqual(
+            try await response.bodyData,
+            #"{"fish": "cakes"}"#.data(using: .utf8)
+        )
     }
 
     func testDirectoryHandler_ReturnsSubDirectoryFile() async throws {
@@ -59,7 +65,10 @@ final class DirectoryHTTPHandlerTests: XCTestCase {
         let response = try await handler.handleRequest(.make(path: "server/path/subdir/vinegar.json"))
         XCTAssertEqual(response.statusCode, .ok)
         XCTAssertEqual(response.headers[.contentType], "application/json")
-        XCTAssertEqual(response.body, #"{"type": "malt"}"#.data(using: .utf8))
+        await AsyncAssertEqual(
+            try await response.bodyData,
+            #"{"type": "malt"}"#.data(using: .utf8)
+        )
     }
 
     func testDirectoryHandler_Returns404WhenFileDoesNotExist() async throws {

--- a/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
@@ -80,7 +80,10 @@ final class HTTPHandlerTests: XCTestCase {
         let response = try await handler.handleRequest(.make())
         XCTAssertEqual(response.statusCode, .ok)
         XCTAssertEqual(response.headers[.contentType], "application/json")
-        XCTAssertEqual(response.body, #"{"fish": "cakes"}"#.data(using: .utf8))
+        await AsyncAssertEqual(
+            try await response.bodyData,
+            #"{"fish": "cakes"}"#.data(using: .utf8)
+        )        
     }
 
     func testFileHandler_ReturnsSuppliedContentType() async throws {

--- a/FlyingFox/Tests/WebSocket/WSHandlerTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSHandlerTests.swift
@@ -127,7 +127,7 @@ final class WSHandlerTests: XCTestCase {
     }
 }
 
-private extension MessageFrameWSHandler {
+extension MessageFrameWSHandler {
 
     static func make(handler: WSMessageHandler = Messages(),
                      frameSize: Int = 1024) -> Self {

--- a/FlyingSocks/Tests/AsyncDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncDataSequenceTests.swift
@@ -231,7 +231,8 @@ final class AsyncDataSequenceTests: XCTestCase {
 
 private extension URL {
     static var jackOfHeartsRecital: URL {
-        Bundle.module.url(forResource: "Resources/JackOfHeartsRecital.txt", withExtension: nil)!
+        Bundle.module.url(forResource: "Resources", withExtension: nil)!
+            .appendingPathComponent("JackOfHeartsRecital.txt")
     }
 }
 

--- a/FlyingSocks/Tests/Resources/JackOfHeartsRecital.txt
+++ b/FlyingSocks/Tests/Resources/JackOfHeartsRecital.txt
@@ -1,0 +1,5 @@
+Two doors down the boys finally made it through the wall
+And cleaned out the bank safe, it's said they got off with quite a haul.
+In the darkness by the riverbed they waited on the ground
+For one more member who had business back in town.
+But they couldn't go no further without the Jack of Hearts.

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,10 @@ let package = Package(
         .testTarget(
             name: "FlyingSocksTests",
             dependencies: ["FlyingSocks"],
-            path: "FlyingSocks/Tests"
+            path: "FlyingSocks/Tests",
+            resources: [
+                .copy("Resources")
+            ]
         ),
         .target(
              name: "CSystemLinux",


### PR DESCRIPTION
In current versions ([0.10.0](https://github.com/swhitty/FlyingFox/releases/tag/0.10.0) and earlier) each HTTPResponse instance includes the entire response body within the var payload: Payload property limiting the size of responses that can be returned.

### HTTPBodySequence
[PR#56 ](https://github.com/swhitty/FlyingFox/pull/56) added `HTTPBodySequence` allowing the body of requests to be backed by either a complete `Data` instance, or from the underlying socket serving the request.

This PR updates `HTTPResponse` so that its `payload` property can now be a `HTTPBodySequence` instance allowing large files on disk to be streamed in the response:

```swift
HTTPResponse(
  statusCode: .ok,
  body: try HTTPBodySequence(file: URL(fileURLWithPath: "/Users/swhitty/Downloads/Xcode_14.3.xip"))
)
```

### FileHTTPHandler
`FileHTTPHandler` has been updated to automatically use the file streaming response when the file size is > 10 megabytes.  Smaller files are returned using the existing complete `Data` method.
