### PR TITLE
isListening public API

### DIFF
--- a/FlyingFox/Sources/HTTPServer+Listening.swift
+++ b/FlyingFox/Sources/HTTPServer+Listening.swift
@@ -35,6 +35,8 @@ import FlyingSocks
 
 extension HTTPServer {
 
+    public var isListening: Bool { state != nil }
+
     public func waitUntilListening(timeout: TimeInterval = 5) async throws {
         try await withThrowingTimeout(seconds: timeout) {
             try await self.doWaitUntilListening()

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -92,7 +92,6 @@ public final actor HTTPServer {
         }
     }
 
-    var isListening: Bool { state != nil }
     var waiting: Set<Continuation> = []
     private(set) var state: (socket: Socket, task: Task<Void, Error>)? {
         didSet { isListeningDidUpdate(from: oldValue != nil ) }


### PR DESCRIPTION
Makes the existing `var isListening: Bool` property of `HTTPServer` public as suggested by @aayush9029 in https://github.com/swhitty/FlyingFox/issues/58

While this is very similar to the existing throwing method:

```swift
try await server.waitUntilListening()
```

I think the `Bool` property can read nicer than `throws` in some scenarios:

```swift
await server.isListening
```



