### PR TITLE
DiscardingTaskGroup

### DIFF
--- a/docker-run-tests.sh
+++ b/docker-run-tests.sh
@@ -5,5 +5,5 @@ set -eu
 docker run -it \
   --rm \
   --mount src="$(pwd)",target=/flyingfox,type=bind \
-  swift \
+  swiftlang/swift:nightly-5.9-jammy \
   /usr/bin/swift test --package-path /flyingfox


### PR DESCRIPTION
`HTTPServer` now uses `DiscardingTaskGroup` for all connections when available
- Swift 5.9
- macOS 14.0, iOS 16.4, tvOS 16.4

The [documentation states](https://developer.apple.com/documentation/swift/discardingtaskgroup/) that macOS 13.3 and later include `DiscardingTaskGroup` but this currently crashes if used on this version — so using `macOS 14.0` for now.