### PR TITLE
Fix buffer leak

### DIFF
--- a/FlyingSocks/Sources/SocketAddress.swift
+++ b/FlyingSocks/Sources/SocketAddress.swift
@@ -125,6 +125,7 @@ extension Socket {
             var addr_in = try sockaddr_in.make(from: addr)
             let maxLength = socklen_t(INET_ADDRSTRLEN)
             let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: Int(maxLength))
+            defer { buffer.deallocate() }
             try Socket.inet_ntop(AF_INET, &addr_in.sin_addr, buffer, maxLength)
             return .ip4(String(cString: buffer), port: UInt16(addr_in.sin_port).byteSwapped)
 
@@ -132,6 +133,7 @@ extension Socket {
             var addr_in6 = try sockaddr_in6.make(from: addr)
             let maxLength = socklen_t(INET6_ADDRSTRLEN)
             let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: Int(maxLength))
+            defer { buffer.deallocate() }
             try Socket.inet_ntop(AF_INET6, &addr_in6.sin6_addr, buffer, maxLength)
             return .ip6(String(cString: buffer), port: UInt16(addr_in6.sin6_port).byteSwapped)
 


### PR DESCRIPTION
The `UnsafeMutablePointer` instances should be deallocated once they are no longer needed.