### PR TITLE
Add Github Action Build for Swift 5.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  xcode_14_3:
+  xcode_14_3_1:
     runs-on: macos-13
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -111,6 +111,19 @@ jobs:
   linux_swift_5_8:
     runs-on: ubuntu-latest
     container: swift:5.8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build --build-tests
+      - name: Test
+        run: swift test --skip-build
+
+  linux_swift_5_9:
+    runs-on: ubuntu-latest
+    container: swift:5.9
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build](https://github.com/swhitty/FlyingFox/actions/workflows/build.yml/badge.svg)](https://github.com/swhitty/FlyingFox/actions/workflows/build.yml)
 [![Codecov](https://codecov.io/gh/swhitty/FlyingFox/graphs/badge.svg)](https://codecov.io/gh/swhitty/FlyingFox)
 [![Platforms](https://img.shields.io/badge/platforms-iOS%20|%20Mac%20|%20tvOS%20|%20Linux%20|%20Windows-lightgray.svg)](https://github.com/swhitty/FlyingFox/blob/main/Package.swift)
-[![Swift 5.8](https://img.shields.io/badge/swift-5.5%20–%205.8-red.svg?style=flat)](https://developer.apple.com/swift)
+[![Swift 5.9](https://img.shields.io/badge/swift-5.5%20–%205.9-red.svg?style=flat)](https://developer.apple.com/swift)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://opensource.org/licenses/MIT)
 [![Twitter](https://img.shields.io/badge/twitter-@simonwhitty-blue.svg)](http://twitter.com/simonwhitty)
 


### PR DESCRIPTION
Add GitHub Action build using linux[ `swift:5.9`](https://hub.docker.com/_/swift/) image.