### PR TITLE
Handler Macro (@HTTPRoute / @JSONRoute)

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/FlyingFox-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FlyingFox-Package.xcscheme
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlyingFox"
+               BuildableName = "FlyingFox"
+               BlueprintName = "FlyingFox"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlyingSocks"
+               BuildableName = "FlyingSocks"
+               BlueprintName = "FlyingSocks"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlyingFoxTests"
+               BuildableName = "FlyingFoxTests"
+               BlueprintName = "FlyingFoxTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlyingSocksTests"
+               BuildableName = "FlyingSocksTests"
+               BlueprintName = "FlyingSocksTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlyingFoxTests"
+               BuildableName = "FlyingFoxTests"
+               BlueprintName = "FlyingFoxTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlyingSocksTests"
+               BuildableName = "FlyingSocksTests"
+               BlueprintName = "FlyingSocksTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FlyingFox"
+            BuildableName = "FlyingFox"
+            BlueprintName = "FlyingFox"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/FlyingFox.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FlyingFox.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlyingFox"
+               BuildableName = "FlyingFox"
+               BlueprintName = "FlyingFox"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FlyingFox"
+            BuildableName = "FlyingFox"
+            BlueprintName = "FlyingFox"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/FlyingSocks.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FlyingSocks.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlyingSocks"
+               BuildableName = "FlyingSocks"
+               BlueprintName = "FlyingSocks"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FlyingSocks"
+            BuildableName = "FlyingSocks"
+            BlueprintName = "FlyingSocks"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FlyingFox/Sources/Handlers/HTTPHandlerMacro.swift
+++ b/FlyingFox/Sources/Handlers/HTTPHandlerMacro.swift
@@ -1,0 +1,41 @@
+//
+//  HTTPHandlerMacro.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 26/10/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+#if compiler(>=5.9)
+
+@attached(peer)
+public macro HTTPRoute(_ name: StringLiteralType, statusCode: HTTPStatusCode = .ok) = #externalMacro(module: "Macro", type: "HTTPRouteMacro")
+
+@attached(member, names: named(performAction), named(Action), named(handleRequest))
+@attached(extension, conformances: HTTPHandler, Sendable)
+public macro HTTPHandler() = #externalMacro(module: "Macro", type: "HTTPHandlerMacro")
+
+#endif

--- a/FlyingFox/Sources/Handlers/HTTPHandlerMacro.swift
+++ b/FlyingFox/Sources/Handlers/HTTPHandlerMacro.swift
@@ -30,9 +30,23 @@
 //
 
 #if compiler(>=5.9)
+import Foundation
 
 @attached(peer)
-public macro HTTPRoute(_ name: StringLiteralType, statusCode: HTTPStatusCode = .ok) = #externalMacro(module: "Macro", type: "HTTPRouteMacro")
+public macro HTTPRoute(
+    _ route: StringLiteralType,
+    statusCode: HTTPStatusCode = .ok,
+    headers: [HTTPHeader: String] = [:]
+) = #externalMacro(module: "Macro", type: "HTTPRouteMacro")
+
+@attached(peer)
+public macro JSONRoute(
+    _ route: StringLiteralType,
+    statusCode: HTTPStatusCode = .ok,
+    headers: [HTTPHeader: String] = [.contentType: "application/json"],
+    encoder: JSONEncoder = JSONEncoder(),
+    decoder: JSONDecoder = JSONDecoder()
+) = #externalMacro(module: "Macro", type: "JSONRouteMacro")
 
 @attached(member, names: named(performAction), named(Action), named(handleRequest))
 @attached(extension, conformances: HTTPHandler, Sendable)

--- a/FlyingFox/Tests/Handlers/HTTPHandlerMacroTests.swift
+++ b/FlyingFox/Tests/Handlers/HTTPHandlerMacroTests.swift
@@ -1,0 +1,74 @@
+//
+//  HTTPHandlerMacroTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 28/10/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+
+
+@testable import FlyingFox
+import XCTest
+
+#if compiler(>=5.9)
+final class HTTPHandlerMacroTests: XCTestCase {
+
+    func testHandler() async throws {
+        let handler = MacroHandler()
+
+        await AsyncAssertEqual(
+            try await handler.handleRequest(.make(path: "/ok")).statusCode,
+            .ok
+        )
+        await AsyncAssertEqual(
+            try await handler.handleRequest(.make(path: "/accepted")).statusCode,
+            .accepted
+        )
+        await AsyncAssertEqual(
+            try await handler.handleRequest(.make(path: "/teapot")).statusCode,
+            .teapot
+        )
+    }
+}
+
+@HTTPHandler
+struct MacroHandler {
+
+    @HTTPRoute("/ok")
+    func didAppear() -> HTTPResponse {
+        HTTPResponse(statusCode: .ok)
+    }
+
+    @HTTPRoute("/accepted")
+    func willAppear(_ val: HTTPRequest) async -> HTTPResponse {
+        HTTPResponse(statusCode: .accepted)
+    }
+
+    @HTTPRoute("/teapot", statusCode: .teapot)
+    func willAppear() throws { }
+}
+#endif

--- a/Macro/Sources/CustomError.swift
+++ b/Macro/Sources/CustomError.swift
@@ -31,6 +31,7 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxMacros
 
 enum CustomError: Error, CustomStringConvertible {
   case message(String)
@@ -41,4 +42,30 @@ enum CustomError: Error, CustomStringConvertible {
       return text
     }
   }
+}
+
+struct SimpleDiagnostic: DiagnosticMessage {
+    var message: String
+    var diagnosticID: MessageID
+    var severity: DiagnosticSeverity
+
+    static func warning(_ message: String) -> Self {
+        SimpleDiagnostic(
+            message: message,
+            diagnosticID: .init(domain: "Macro", id: message),
+            severity: .warning
+        )
+    }
+}
+
+extension MacroExpansionContext {
+
+    func diagnoseWarning(for node: some SyntaxProtocol, _ message: String) {
+        diagnose(
+          Diagnostic(
+            node: node,
+            message: SimpleDiagnostic.warning(message)
+          )
+        )
+    }
 }

--- a/Macro/Sources/CustomError.swift
+++ b/Macro/Sources/CustomError.swift
@@ -1,0 +1,44 @@
+//
+//  CustomError.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 26/10/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import SwiftDiagnostics
+import SwiftSyntax
+
+enum CustomError: Error, CustomStringConvertible {
+  case message(String)
+
+  var description: String {
+    switch self {
+    case .message(let text):
+      return text
+    }
+  }
+}

--- a/Macro/Sources/FunctionDecl.swift
+++ b/Macro/Sources/FunctionDecl.swift
@@ -1,0 +1,175 @@
+//
+//  FunctionDecl.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 26/10/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import SwiftSyntax
+
+struct FunctionDecl {
+    var name: String
+    var parameters: [Parameter]
+    var effects: Effects
+    var attributes: [Attribute]
+    var returnType: ReturnType
+
+    struct Parameter {
+        var label: String?
+        var name: String
+        var type: String
+    }
+
+    struct Attribute {
+        var name: String
+        var labelExpressions: [LabelExpression]
+
+        struct LabelExpression {
+            var name: String?
+            var expression: String
+        }
+
+        func expression(name: String) -> LabelExpression? {
+            labelExpressions.first { $0.name == name }
+        }
+    }
+
+    enum ReturnType {
+        case void
+        case type(String)
+    }
+
+    struct Effects: OptionSet {
+        var rawValue: Int = 0
+
+        static let async = Effects(rawValue: 1 << 1)
+        static let `throws` = Effects(rawValue: 1 << 2)
+    }
+
+    func attribute(name: String) -> Attribute? {
+        attributes.first { $0.name == name }
+    }
+}
+
+
+extension FunctionDecl {
+
+    static func make(from syntax: FunctionDeclSyntax) -> Self {
+        var decl = FunctionDecl(
+            name: syntax.name.text,
+            parameters: [],
+            effects: [],
+            attributes: [],
+            returnType: .init(syntax.signature.returnClause?.type.as(IdentifierTypeSyntax.self)?.name.text)
+        )
+
+        decl.attributes = syntax.attributes
+            .compactMap {
+                $0.as(AttributeSyntax.self)
+            }
+            .compactMap(Attribute.make)
+
+        decl.parameters = syntax.signature
+            .parameterClause
+            .parameters
+            .compactMap { param in
+                guard let typeID = param.type.as(IdentifierTypeSyntax.self) else { return nil }
+                return FunctionDecl.Parameter(
+                    label: param.firstName.text == "_" ? nil : param.firstName.text,
+                    name: param.secondName?.text ?? param.firstName.text,
+                    type: typeID.name.text
+                )
+            }
+
+        if syntax.signature.effectSpecifiers?.asyncSpecifier != nil {
+            decl.effects.insert(.async)
+        }
+
+        if syntax.signature.effectSpecifiers?.throwsSpecifier != nil {
+            decl.effects.insert(.throws)
+        }
+
+        return decl
+    }
+}
+
+extension FunctionDecl.Attribute {
+
+    static func make(from syntax: AttributeSyntax) -> Self? {
+        guard let name = syntax.attributeName.as(IdentifierTypeSyntax.self)?.name.text else {
+            return nil
+        }
+
+        var decl = FunctionDecl.Attribute (
+            name: name,
+            labelExpressions: []
+        )
+
+        guard let labelSyntax = syntax.arguments?.as(LabeledExprListSyntax.self) else {
+            return decl
+        }
+
+        decl.labelExpressions = labelSyntax
+            .map(LabelExpression.make)
+
+        return decl
+    }
+}
+
+extension FunctionDecl.Attribute.LabelExpression {
+
+    static func make(from syntax: LabeledExprSyntax) -> Self {
+        let name = syntax.label?.text
+        let expression = try? syntax.expression
+            .as(StringLiteralExprSyntax.self)?
+            .singleStringSegment()
+
+        return Self(
+            name: name == "_" ? nil : name,
+            expression: expression ?? String(describing: syntax.expression)
+        )
+    }
+}
+
+extension FunctionDecl.ReturnType: Equatable {
+
+    init(_ value: String?) {
+        switch value {
+        case .none, "()", "Void":
+            self = .void
+        case .some(let string):
+            self = .type(string)
+        }
+    }
+}
+
+extension FunctionDecl.ReturnType: ExpressibleByStringLiteral {
+
+    public init(stringLiteral value: String) {
+        self = .init(value)
+    }
+}

--- a/Macro/Sources/FunctionDecl.swift
+++ b/Macro/Sources/FunctionDecl.swift
@@ -75,8 +75,14 @@ struct FunctionDecl {
     }
 }
 
-
 extension FunctionDecl {
+
+    static func make(from syntax: MemberBlockItemSyntax) -> Self? {
+        guard let funcSyntax = syntax.decl.as(FunctionDeclSyntax.self) else {
+            return nil
+        }
+        return .make(from: funcSyntax)
+    }
 
     static func make(from syntax: FunctionDeclSyntax) -> Self {
         var decl = FunctionDecl(
@@ -171,5 +177,37 @@ extension FunctionDecl.ReturnType: ExpressibleByStringLiteral {
 
     public init(stringLiteral value: String) {
         self = .init(value)
+    }
+}
+
+extension FunctionDecl.ReturnType {
+
+    var isVoid: Bool {
+        switch self {
+        case .void:
+            return true
+        case .type(let string):
+            return FunctionDecl.ReturnType.void == .init(string)
+        }
+    }
+
+    var isHTTPResponse: Bool {
+        switch self {
+        case .void:
+            return false
+        case .type(let string):
+            return string.isHTTPResponse
+        }
+    }
+}
+
+extension String {
+
+    var isHTTPResponse: Bool {
+        self == "HTTPResponse" || self == "FlyingFox.HTTPResponse"
+    }
+
+    var isHTTPRequest: Bool {
+        self == "HTTPRequest" || self == "FlyingFox.HTTPRequest"
     }
 }

--- a/Macro/Sources/HTTPHandlerMacro.swift
+++ b/Macro/Sources/HTTPHandlerMacro.swift
@@ -1,0 +1,156 @@
+//
+//  HTTPHandlerMacro.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 26/10/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public enum HTTPHandlerMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        let memberList = declaration.memberBlock.members
+
+        let routes = memberList.compactMap { member -> RouteDecl? in
+            guard let funcSyntax = member.decl.as(FunctionDeclSyntax.self) else {
+                return nil
+            }
+
+            let funcDecl = FunctionDecl.make(from: funcSyntax)
+            guard let routeAtt = funcDecl.attribute(name: "HTTPRoute") else {
+                return nil
+            }
+
+            guard let firstLabel = routeAtt.labelExpressions.first else {
+                return nil
+            }
+
+            return RouteDecl(
+                route: firstLabel.expression,
+                statusCode: routeAtt.expression(name: "statusCode")?.expression ?? ".ok",
+                funcDecl: funcDecl
+            )
+        }
+
+        var validRoutes = Set<String>()
+        for route in routes {
+            guard !validRoutes.contains(route.route) else {
+                throw CustomError.message(
+                    "@HTTPRoute(\"\(route.route)\") is ambiguous"
+                )
+            }
+            validRoutes.insert(route.route)
+        }
+
+        let routeDecl: DeclSyntax = """
+        func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
+            \(raw: routes.map(\.routeSyntax).joined(separator: "\n"))
+            throw HTTPUnhandledError()
+        }
+        """
+
+        //
+
+        return [
+            routeDecl
+        ]
+    }
+}
+
+extension HTTPHandlerMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        [try ExtensionDeclSyntax("extension \(type.trimmed): HTTPHandler {}")]
+    }
+}
+
+private extension HTTPHandlerMacro {
+    struct RouteDecl {
+        var route: String
+        var statusCode: String
+        var funcDecl: FunctionDecl
+
+        var routeSyntax: String {
+            if funcDecl.returnType.isVoid {
+                return """
+                if await HTTPRoute("\(route)") ~= request { \(funcCallSyntax)
+                return HTTPResponse(statusCode: \(statusCode))
+                }
+                """
+            } else {
+                return """
+                if await HTTPRoute("\(route)") ~= request { return \(funcCallSyntax) }
+                """
+            }
+        }
+
+        var funcCallSyntax: String {
+            var call = ""
+            if funcDecl.effects.contains(.throws) {
+                call += "try "
+            }
+            if funcDecl.effects.contains(.async) {
+                call += "await "
+            }
+            call += funcDecl.name
+            if let param = funcDecl.parameters.first {
+                if let label = param.label {
+                    call += "(" + label + ": request)"
+                } else {
+                    call += "(request)"
+                }
+            } else {
+                call += "()"
+            }
+            return call
+        }
+    }
+}
+
+extension StringLiteralExprSyntax {
+
+    func singleStringSegment() throws -> String {
+        guard segments.count == 1,
+              case let .stringSegment(segment)? = segments.first else {
+            throw CustomError.message(
+                "invalid String Literal"
+            )
+        }
+        return segment.content.text
+    }
+}

--- a/Macro/Sources/HTTPRouteMacro.swift
+++ b/Macro/Sources/HTTPRouteMacro.swift
@@ -1,0 +1,110 @@
+//
+//  HTTPRouteMacro.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 26/10/2023.
+//  Copyright © 2023 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct HTTPRouteMacro: PeerMacro {
+    public static func expansion<
+        Context: MacroExpansionContext,
+        Declaration: DeclSyntaxProtocol
+    >(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: Declaration,
+        in context: Context
+    ) throws -> [DeclSyntax] {
+
+        // Only func can be a route
+        guard let funcSyntax = declaration.as(FunctionDeclSyntax.self) else {
+            throw CustomError.message("@HTTPRoute can only be attacehd to functions")
+        }
+
+        let funcDecl = FunctionDecl.make(from: funcSyntax)
+        let routeAtt = funcDecl.attribute(name: "HTTPRoute")!
+
+        if funcDecl.returnType.isHTTPResponse {
+            guard routeAtt.expression(name: "statusCode") == nil else {
+                throw CustomError.message(
+                    "statusCode can not be supplied when returning HTTPResponse"
+                )
+            }
+        }
+
+        guard funcDecl.returnType.isVoid || funcDecl.returnType.isHTTPResponse else {
+            throw CustomError.message(
+                "@Route requires an function that returns HTTPResponse"
+            )
+        }
+
+        guard funcDecl.parameters.isEmpty ||
+                (funcDecl.parameters[0].type.isHTTPRequest && funcDecl.parameters.count == 1) else {
+            throw CustomError.message(
+                "@Route requires an function with argument `HTTPRequest`"
+            )
+        }
+
+        // Does nothing, used only to decorate functions with data
+        return []
+    }
+}
+
+extension String {
+
+    var isHTTPResponse: Bool {
+        self == "HTTPResponse" || self == "FlyingFox.HTTPResponse"
+    }
+
+    var isHTTPRequest: Bool {
+        self == "HTTPRequest" || self == "FlyingFox.HTTPRequest"
+    }
+}
+
+extension FunctionDecl.ReturnType {
+
+    var isVoid: Bool {
+        switch self {
+        case .void:
+            return true
+        case .type(let string):
+            return FunctionDecl.ReturnType.void == .init(string)
+        }
+    }
+
+    var isHTTPResponse: Bool {
+        switch self {
+        case .void: 
+            return false
+        case .type(let string):
+            return string.isHTTPResponse
+        }
+    }
+}

--- a/Macro/Sources/Plugin.swift
+++ b/Macro/Sources/Plugin.swift
@@ -5,6 +5,7 @@ import SwiftSyntaxMacros
 struct MyMacroPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
         HTTPRouteMacro.self,
+        JSONRouteMacro.self,
         HTTPHandlerMacro.self
     ]
 }

--- a/Macro/Sources/Plugin.swift
+++ b/Macro/Sources/Plugin.swift
@@ -1,0 +1,10 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct MyMacroPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        HTTPRouteMacro.self,
+        HTTPHandlerMacro.self
+    ]
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "ffa3cd6fc2aa62adbedd31d3efaf7c0d86a9f029",
+        "version" : "509.0.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -30,7 +30,7 @@ let package = Package(
         ),
         .testTarget(
             name: "FlyingFoxTests",
-            dependencies: ["FlyingFox"],
+            dependencies: ["FlyingFox", "Macro"],
             path: "FlyingFox/Tests",
             resources: [
                 .copy("Stubs")

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,0 +1,65 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+    name: "FlyingFox",
+    platforms: [
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "FlyingFox",
+            targets: ["FlyingFox"]
+        ),
+        .library(
+            name: "FlyingSocks",
+            targets: ["FlyingSocks"]
+        )
+    ],
+    dependencies: [
+        // Depend on the Swift 5.9 release of SwiftSyntax
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "FlyingFox",
+            dependencies: ["FlyingSocks", "Macro"],
+            path: "FlyingFox/Sources"
+        ),
+        .testTarget(
+            name: "FlyingFoxTests",
+            dependencies: ["FlyingFox"],
+            path: "FlyingFox/Tests",
+            resources: [
+                .copy("Stubs")
+            ]
+        ),
+        .target(
+            name: "FlyingSocks",
+            dependencies: [.target(name: "CSystemLinux", condition: .when(platforms: [.linux]))],
+            path: "FlyingSocks/Sources"
+        ),
+        .testTarget(
+            name: "FlyingSocksTests",
+            dependencies: ["FlyingSocks"],
+            path: "FlyingSocks/Tests",
+            resources: [
+                .copy("Resources")
+            ]
+        ),
+        .target(
+             name: "CSystemLinux",
+             path: "CSystemLinux"
+        ),
+        .macro(
+            name: "Macro",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ],
+            path: "Macro/Sources"
+        )
+    ]
+)


### PR DESCRIPTION
An experimental preview of `@HTTPRoute` and  `@JSONRoute` to annotate functions with routes. 
The annotations are implemented via [SE-0389 Attached Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0389-attached-macros.md) available in Swift 5.9 and later. 

A handler is able to annotate its functions with routes:

```swift
@HTTPHandler
struct MyHandler {

    @HTTPRoute("/ping")
    func ping() { }
    
    @HTTPRoute("/pong")
    func getPong(_ request: HTTPRequest) -> HTTPResponse {
        HTTPResponse(statusCode: .accepted)
    }
}

let server = HTTPServer(port: 80, handler: MyHandler())
try await server.start()
```

The macro synthesises conformance to `HTTPHandler` delegating handling to the first matching route. Expanding the example above to the following:

```swift
// expanded macro synthesis
func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
  if await HTTPRoute("/ping") ~= request {
    ping()
    return HTTPResponse(statusCode: .ok, headers: [:])
  }
  if await HTTPRoute("/pong") ~= request {
    return getPong(request)
  }
  throw HTTPUnhandledError()
}
```

`@HTTPRoute` annotations can specify specific properties of the returned `HTTPResponse`:

```swift
@HTTPRoute("/refresh", statusCode: .teapot, headers: [.eTag: "t3a"])
func refresh()
```

`@JSONRoute` annotations can be added to functions that accept `Codable` types. `JSONDecoder` decodes the body that is passed to the method, the returned object is encoded to the response body using `JSONEncoder`:

```swift
@JSONRoute("POST /account")
func createAccount(body: AccountRequest) -> AccountResponse
```

The original `HTTPRequest` can be optionally passed to the method:

```swift
@JSONRoute("POST /account")
func createAccount(request: HTTPRequest, body: AccountRequest) -> AccountResponse
```

`JSONEncoder` / `JSONDecoder` instances can be passed for specific JSON coding strategies:

```swift
@JSONRoute("GET /account", encoder: JSONEncoder())
func getAccount() -> AccountResponse
```