### PR TITLE
Support Percent Encoded Paths

### DIFF
--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -88,7 +88,7 @@ struct HTTPDecoder {
     }
 
     static func makeComponents(from comps: URLComponents?) -> (path: String, query: [HTTPRequest.QueryItem]) {
-        let path = (comps?.path).flatMap { URL(string: $0)?.standardized.path } ?? ""
+        let path = (comps?.percentEncodedPath).flatMap { URL(string: $0)?.standardized.path } ?? ""
         let query = comps?.queryItems?.map {
             HTTPRequest.QueryItem(name: $0.name, value: $0.value ?? "")
         }

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -218,6 +218,28 @@ final class HTTPDecoderTests: XCTestCase {
         )
     }
 
+    func testPercentEncodedPathDecodes() {
+        XCTAssertEqual(
+            HTTPDecoder.readComponents(from: "/fish%20chips").path,
+            "/fish chips"
+        )
+        XCTAssertEqual(
+            HTTPDecoder.readComponents(from: "/ocean/fish%20and%20chips").path,
+            "/ocean/fish and chips"
+        )
+    }
+
+    func testPercentQueryStringDecodes() {
+        XCTAssertEqual(
+            HTTPDecoder.readComponents(from: "/?fish=%F0%9F%90%9F").query,
+            [.init(name: "fish", value: "🐟")]
+        )
+        XCTAssertEqual(
+            HTTPDecoder.readComponents(from: "?%F0%9F%90%A1=chips").query,
+            [.init(name: "🐡", value: "chips")]
+        )
+    }
+
     func testEmptyQueryItem_Decodes() {
         var urlComps = URLComponents()
         urlComps.queryItems = [.init(name: "name", value: nil)]

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -62,6 +62,39 @@ final class HTTPRouteTests: XCTestCase {
         )
     }
 
+    func testPercentEncodedPathComponents() {
+        XCTAssertEqual(
+            HTTPRoute("GET /hello world").path,
+            [.caseInsensitive("hello world")]
+        )
+
+        XCTAssertEqual(
+            HTTPRoute("/hello%20world").path,
+            [.caseInsensitive("hello world")]
+        )
+
+        XCTAssertEqual(
+            HTTPRoute("🐡/*").path,
+            [.caseInsensitive("🐡"), .wildcard]
+        )
+
+        XCTAssertEqual(
+            HTTPRoute("%F0%9F%90%A1/*").path,
+            [.caseInsensitive("🐡"), .wildcard]
+        )
+    }
+
+    func testPercentEncodedQueryItems() {
+        XCTAssertEqual(
+            HTTPRoute("/?fish=%F0%9F%90%9F").query,
+            [.init(name: "fish", value: .caseInsensitive("🐟"))]
+        )
+        XCTAssertEqual(
+            HTTPRoute("/?%F0%9F%90%A1=chips").query,
+            [.init(name: "🐡", value: .caseInsensitive("chips"))]
+        )
+    }
+
     func testMethod() {
         XCTAssertEqual(
             HTTPRoute("hello/world").method,


### PR DESCRIPTION
Adds support for parsing requests with percent encoded paths.

Routes can be added including spaces:
```swift
server.appendRoute("/fish & chips") { _ in
  HTTPResponse(
    statusCode: .ok,
    headers: [.contentType: "text/plain; charset=UTF-8"],
    body: "🐟🍟".data(using: .utf8)!
  )
}
```

Requests are decoded and matched against the unescaped Routes:
```
% curl "localhost/fish%20&%20chips"
🐟🍟
```

Resolves #74