### PR TITLE
Swift 5.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  xcode_14_3_1:
-    runs-on: macos-13
+  xcode_15_2:
+    runs-on: macos-14
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,10 +26,10 @@ jobs:
         with:
           files: ./coverage_report.lcov
 
-  xcode_15_1:
+  xcode_14_3_1:
     runs-on: macos-13
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -54,9 +54,22 @@ jobs:
       - name: Test
         run: swift test --skip-build
 
-  linux_swift_5_7:
+  linux_swift_5_10:
     runs-on: ubuntu-latest
-    container: swift:5.7
+    container: swift:5.10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build --build-tests
+      - name: Test
+        run: swift test --skip-build
+
+  linux_swift_5_9:
+    runs-on: ubuntu-latest
+    container: swift:5.9
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -80,9 +93,9 @@ jobs:
       - name: Test
         run: swift test --skip-build
 
-  linux_swift_5_9:
+  linux_swift_5_7:
     runs-on: ubuntu-latest
-    container: swift:5.9
+    container: swift:5.7
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Gather code coverage
         run: xcrun llvm-cov export -format="lcov" .build/debug/FlyingFoxPackageTests.xctest/Contents/MacOS/FlyingFoxPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage_report.lcov
       - name: Upload Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage_report.lcov
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Version
         run: swift --version
       - name: Build
@@ -32,7 +32,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Version
         run: swift --version
       - name: Build
@@ -46,7 +46,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Version
         run: swift --version
       - name: Build
@@ -59,7 +59,7 @@ jobs:
     container: swift:5.10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Version
         run: swift --version
       - name: Build
@@ -72,7 +72,7 @@ jobs:
     container: swift:5.9
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Version
         run: swift --version
       - name: Build
@@ -85,7 +85,7 @@ jobs:
     container: swift:5.8
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Version
         run: swift --version
       - name: Build
@@ -98,7 +98,7 @@ jobs:
     container: swift:5.7
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Version
         run: swift --version
       - name: Build

--- a/FlyingFox/Sources/HTTPHandler.swift
+++ b/FlyingFox/Sources/HTTPHandler.swift
@@ -71,7 +71,7 @@ public extension HTTPHandler where Self == ClosureHTTPHandler {
 }
 
 public extension HTTPHandler where Self == WebSocketHTTPHandler {
-    static func webSocket(_ handler: WSMessageHandler, frameSize: Int = 16384) -> WebSocketHTTPHandler {
+    static func webSocket(_ handler: some WSMessageHandler, frameSize: Int = 16384) -> WebSocketHTTPHandler {
         WebSocketHTTPHandler(handler: MessageFrameWSHandler(handler: handler, frameSize: frameSize))
     }
 }

--- a/FlyingFox/Sources/HTTPLogging.swift
+++ b/FlyingFox/Sources/HTTPLogging.swift
@@ -46,11 +46,11 @@ public extension Logging where Self == PrintLogger {
 
 extension HTTPServer {
 
-    public static func defaultLogger(category: String = "FlyingFox") -> Logging {
+    public static func defaultLogger(category: String = "FlyingFox") -> any Logging {
         defaultLogger(category: category, forceFallback: false)
     }
 
-    static func defaultLogger(category: String = "FlyingFox", forceFallback: Bool) -> Logging {
+    static func defaultLogger(category: String = "FlyingFox", forceFallback: Bool) -> any Logging {
         guard !forceFallback, #available(macOS 11.0, iOS 14.0, tvOS 14.0, *) else {
             return .print(category: category)
         }

--- a/FlyingFox/Sources/HTTPResponse.swift
+++ b/FlyingFox/Sources/HTTPResponse.swift
@@ -39,7 +39,7 @@ public struct HTTPResponse: Sendable {
 
     public enum Payload: @unchecked Sendable {
         case httpBody(HTTPBodySequence)
-        case webSocket(WSHandler)
+        case webSocket(any WSHandler)
 
         @available(*, unavailable, renamed: "httpBody")
         static func body(_ data: Data) -> Self {
@@ -94,7 +94,7 @@ public struct HTTPResponse: Sendable {
     }
 
     public init(headers: [HTTPHeader: String] = [:],
-                webSocket handler: WSHandler) {
+                webSocket handler: some WSHandler) {
         self.version = .http11
         self.statusCode = .switchingProtocols
         self.headers = headers

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -36,18 +36,18 @@ public struct HTTPRoute: Sendable {
     public var path: [Component]
     public var query: [QueryItem]
     public var headers: [HTTPHeader: Component]
-    public var body: HTTPBodyPattern?
+    public var body: (any HTTPBodyPattern)?
 
-    public init(_ string: String, headers: [HTTPHeader: String] = [:], body: HTTPBodyPattern? = nil) {
+    public init(_ string: String, headers: [HTTPHeader: String] = [:], body: (any HTTPBodyPattern)? = nil) {
         let comps = Self.components(for: string)
         self.init(method: comps.method, path: comps.path, headers: headers, body: body)
     }
 
-    public init(method: HTTPMethod, path: String, headers: [HTTPHeader: String] = [:], body: HTTPBodyPattern? = nil) {
+    public init(method: HTTPMethod, path: String, headers: [HTTPHeader: String] = [:], body: (any HTTPBodyPattern)? = nil) {
         self.init(method: method.rawValue, path: path, headers: headers, body: body)
     }
 
-    init(method: String, path: String, headers: [HTTPHeader: String], body: HTTPBodyPattern?) {
+    init(method: String, path: String, headers: [HTTPHeader: String], body: (any HTTPBodyPattern)?) {
         self.method = Component(method)
 
         let comps = HTTPRoute.readComponents(from: path)

--- a/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
@@ -31,11 +31,11 @@
 
 public struct RoutedHTTPHandler: HTTPHandler, Sendable {
 
-    private var handlers: [(route: HTTPRoute, handler: HTTPHandler)] = []
+    private var handlers: [(route: HTTPRoute, handler: any HTTPHandler)] = []
 
     public init() { }
 
-    public mutating func appendRoute(_ route: HTTPRoute, to handler: HTTPHandler) {
+    public mutating func appendRoute(_ route: HTTPRoute, to handler: some HTTPHandler) {
         handlers.append((route, handler))
     }
 

--- a/FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift
@@ -41,10 +41,10 @@ public struct WSInvalidHandshakeError: LocalizedError {
 
 public struct WebSocketHTTPHandler: HTTPHandler, Sendable {
 
-    private let handler: WSHandler
+    private let handler: any WSHandler
     private let acceptedMethods: Set<HTTPMethod>
 
-    public init(handler: WSHandler, accepts methods: Set<HTTPMethod> = [.GET]) {
+    public init(handler: some WSHandler, accepts methods: Set<HTTPMethod> = [.GET]) {
         self.handler = handler
         self.acceptedMethods = methods
     }

--- a/FlyingFox/Sources/URLSession+Async.swift
+++ b/FlyingFox/Sources/URLSession+Async.swift
@@ -52,7 +52,7 @@ extension URLSession {
     }
 
     func makeData(for request: URLRequest) async throws -> (Data, URLResponse) {
-        let continuation = CancellingContinuation<(Data, URLResponse), Error>()
+        let continuation = CancellingContinuation<(Data, URLResponse), any Error>()
         let task = dataTask(with: request) { data, response, error in
             guard let data = data, let response = response else {
                 continuation.resume(throwing: error!)

--- a/FlyingFox/Sources/WebSocket/AsyncStream+WSFrame.swift
+++ b/FlyingFox/Sources/WebSocket/AsyncStream+WSFrame.swift
@@ -31,10 +31,10 @@
 
 import FlyingSocks
 
-extension AsyncThrowingStream where Element == WSFrame, Failure == Error {
+extension AsyncThrowingStream<WSFrame, any Error> {
 
     static func decodingFrames<S: AsyncChunkedSequence>(from bytes: S) -> Self where S.Element == UInt8 {
-        AsyncThrowingStream<WSFrame, Error> {
+        AsyncThrowingStream<WSFrame, any Error> {
             do {
                 return try await WSFrameEncoder.decodeFrame(from: bytes)
             } catch SocketError.disconnected, is SequenceTerminationError {
@@ -46,7 +46,7 @@ extension AsyncThrowingStream where Element == WSFrame, Failure == Error {
     }
 }
 
-extension AsyncStream where Element == WSFrame {
+extension AsyncStream<WSFrame> {
 
     static func protocolFrames<S: AsyncSequence>(from frames: S) -> Self where S.Element == WSFrame {
         var iterator: S.AsyncIterator? = frames.makeAsyncIterator()

--- a/FlyingFox/Tests/AsyncSocketTests.swift
+++ b/FlyingFox/Tests/AsyncSocketTests.swift
@@ -39,7 +39,7 @@ extension AsyncSocket {
         try await make(pool: .client)
     }
 
-    static func make(pool: AsyncSocketPool) throws -> AsyncSocket {
+    static func make(pool: some AsyncSocketPool) throws -> AsyncSocket {
         let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
         return try AsyncSocket(socket: socket, pool: pool)
     }
@@ -48,7 +48,7 @@ extension AsyncSocket {
         try await makePair(pool: .client)
     }
 
-    static func makePair(pool: AsyncSocketPool) throws -> (AsyncSocket, AsyncSocket) {
+    static func makePair(pool: some AsyncSocketPool) throws -> (AsyncSocket, AsyncSocket) {
         let (file1, file2) = Socket.socketpair(AF_UNIX, Socket.stream, 0)
         guard file1.rawValue > -1, file2.rawValue > -1 else {
             throw SocketError.makeFailed("SocketPair")

--- a/FlyingFox/Tests/HTTPConnectionTests.swift
+++ b/FlyingFox/Tests/HTTPConnectionTests.swift
@@ -145,7 +145,7 @@ final class HTTPConnectionTests: XCTestCase {
 
 private extension HTTPConnection {
     init(socket: AsyncSocket) {
-        self.init(socket: socket, logger: nil)
+        self.init(socket: socket, logger: .disabled)
     }
 }
 

--- a/FlyingFox/Tests/HTTPLoggingTests.swift
+++ b/FlyingFox/Tests/HTTPLoggingTests.swift
@@ -86,4 +86,69 @@ final class HTTPLoggingTests: XCTestCase {
             "starting server"
         )
     }
+
+    func testDisabledLogger_DoesNotExecuteDebugClosure() {
+        let logger = DisabledLogger()
+        let didNotReturnString = expectation(description: "debug closure")
+        didNotReturnString.isInverted = true
+
+        logger.logDebug({
+            didNotReturnString.fulfill()
+            return "disabled"
+        }())
+
+        wait(for: [didNotReturnString], timeout: 0.1)
+    }
+
+    func testDisabledLogger_DoesNotExecuteInfoClosure() {
+        let logger = DisabledLogger()
+        let didNotReturnString = expectation(description: "info closure")
+        didNotReturnString.isInverted = true
+
+        logger.logInfo({
+            didNotReturnString.fulfill()
+            return "disabled"
+        }())
+
+        wait(for: [didNotReturnString], timeout: 0.1)
+    }
+
+    func testDisabledLogger_DoesNotExecuteWarningClosure() {
+        let logger = DisabledLogger()
+        let didNotReturnString = expectation(description: "warning closure")
+        didNotReturnString.isInverted = true
+
+        logger.logWarning({
+            didNotReturnString.fulfill()
+            return "disabled"
+        }())
+
+        wait(for: [didNotReturnString], timeout: 0.1)
+    }
+
+    func testDisabledLogger_DoesNotExecuteErrorClosure() {
+        let logger = DisabledLogger()
+        let didNotReturnString = expectation(description: "error closure")
+        didNotReturnString.isInverted = true
+
+        logger.logError({
+            didNotReturnString.fulfill()
+            return "disabled"
+        }())
+
+        wait(for: [didNotReturnString], timeout: 0.1)
+    }
+
+    func testDisabledLogger_DoesNotExecuteCriticalClosure() {
+        let logger = DisabledLogger()
+        let didNotReturnString = expectation(description: "critical closure")
+        didNotReturnString.isInverted = true
+
+        logger.logCritical({
+            didNotReturnString.fulfill()
+            return "disabled"
+        }())
+
+        wait(for: [didNotReturnString], timeout: 0.1)
+    }
 }

--- a/FlyingFox/Tests/HTTPResponse+Mock.swift
+++ b/FlyingFox/Tests/HTTPResponse+Mock.swift
@@ -55,7 +55,7 @@ extension HTTPResponse {
     }
 
     static func make(headers: [HTTPHeader: String] = [:],
-                     webSocket handler: WSHandler) -> Self {
+                     webSocket handler: some WSHandler) -> Self {
         HTTPResponse(headers: headers,
                      webSocket: handler)
     }

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -48,7 +48,7 @@ final class HTTPServerTests: XCTestCase {
     }
 
     @discardableResult
-    func startServer(_ server: HTTPServer) async throws -> Task<Void, Error> {
+    func startServer(_ server: HTTPServer) async throws -> Task<Void, any Error> {
         self.stopServer = server
         let task = Task { try await server.start() }
         try await server.waitUntilListening()
@@ -358,7 +358,7 @@ final class HTTPServerTests: XCTestCase {
     func testWaitUntilListing_WaitsUntil_SocketIsListening() async {
         let server = HTTPServer.make()
 
-        let waiting = Task<Bool, Error> {
+        let waiting = Task<Bool, any Error> {
             try await server.waitUntilListening()
             return true
         }
@@ -372,7 +372,7 @@ final class HTTPServerTests: XCTestCase {
     func testWaitUntilListing_ThrowsWhen_TaskIsCancelled() async {
         let server = HTTPServer.make()
 
-        let waiting = Task<Bool, Error> {
+        let waiting = Task<Bool, any Error> {
             try await server.waitUntilListening()
             return true
         }
@@ -384,12 +384,12 @@ final class HTTPServerTests: XCTestCase {
     func testWaitUntilListing_ThrowsWhen_TimeoutExpires() async throws {
         let server = HTTPServer.make()
 
-        let waiting = Task<Bool, Error> {
+        let waiting = Task<Bool, any Error> {
             try await server.waitUntilListening(timeout: 1)
             return true
         }
 
-        await AsyncAssertThrowsError(try await waiting.value, of: Error.self)
+        await AsyncAssertThrowsError(try await waiting.value, of: (any Error).self)
     }
 }
 
@@ -397,8 +397,8 @@ extension HTTPServer {
 
     static func make<A: SocketAddress>(address: A,
                                        timeout: TimeInterval = 15,
-                                       logger: Logging? = defaultLogger(),
-                                       handler: HTTPHandler? = nil) -> HTTPServer {
+                                       logger: any Logging = defaultLogger(),
+                                       handler: (any HTTPHandler)? = nil) -> HTTPServer {
         HTTPServer(address: address,
                    timeout: timeout,
                    logger: logger,
@@ -407,8 +407,8 @@ extension HTTPServer {
 
     static func make(port: UInt16 = 0,
                      timeout: TimeInterval = 15,
-                     logger: Logging? = nil,
-                     handler: HTTPHandler? = nil) -> HTTPServer {
+                     logger: some Logging = .disabled,
+                     handler: (any HTTPHandler)? = nil) -> HTTPServer {
         HTTPServer(port: port,
                    timeout: timeout,
                    logger: logger,
@@ -417,7 +417,7 @@ extension HTTPServer {
 
     static func make(port: UInt16 = 0,
                      timeout: TimeInterval = 15,
-                     logger: Logging? = nil,
+                     logger: some Logging = .disabled,
                      handler: @Sendable @escaping (HTTPRequest) async throws -> HTTPResponse) -> HTTPServer {
         HTTPServer(port: port,
                    timeout: timeout,

--- a/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
@@ -60,7 +60,7 @@ final class DirectoryHTTPHandlerTests: XCTestCase {
     }
 
     func testDirectoryHandler_ReturnsSubDirectoryFile() async throws {
-        let handler: HTTPHandler = .directory(for: .module, subPath: "Stubs", serverPath: "server/path")
+        let handler: some HTTPHandler = .directory(for: .module, subPath: "Stubs", serverPath: "server/path")
 
         let response = try await handler.handleRequest(.make(path: "server/path/subdir/vinegar.json"))
         XCTAssertEqual(response.statusCode, .ok)
@@ -72,7 +72,7 @@ final class DirectoryHTTPHandlerTests: XCTestCase {
     }
 
     func testDirectoryHandler_Returns404WhenFileDoesNotExist() async throws {
-        let handler: HTTPHandler = .directory(for: .module, subPath: "Stubs", serverPath: "server/path")
+        let handler: some HTTPHandler = .directory(for: .module, subPath: "Stubs", serverPath: "server/path")
 
         let response = try await handler.handleRequest(.make())
         XCTAssertEqual(response.statusCode, .notFound)

--- a/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
@@ -37,7 +37,7 @@ final class HTTPHandlerTests: XCTestCase {
     //MARK: - HTTPHandler
     
     func testUnhandledHandler_ThrowsError() async {
-        let handler: HTTPHandler = .unhandled()
+        let handler: some HTTPHandler = .unhandled()
 
         await AsyncAssertThrowsError(try await handler.handleRequest(.make()), of: HTTPUnhandledError.self)
     }
@@ -75,7 +75,7 @@ final class HTTPHandlerTests: XCTestCase {
     }
     
     func testFileHandler_Returns200WithData() async throws {
-        let handler: HTTPHandler = .file(named: "Stubs/fish.json", in: .module)
+        let handler: some HTTPHandler = .file(named: "Stubs/fish.json", in: .module)
 
         let response = try await handler.handleRequest(.make())
         XCTAssertEqual(response.statusCode, .ok)

--- a/FlyingFox/Tests/Handlers/WebSocketHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/WebSocketHTTPHandlerTests.swift
@@ -198,13 +198,13 @@ private extension Dictionary where Key == HTTPHeader, Value == String {
 }
 
 private extension WebSocketHTTPHandler {
-    static func make(handler: WSHandler = MockHandler(), accepts methods: Set<HTTPMethod> = [.GET]) -> WebSocketHTTPHandler {
+    static func make(handler: some WSHandler = MockHandler(), accepts methods: Set<HTTPMethod> = [.GET]) -> WebSocketHTTPHandler {
         WebSocketHTTPHandler(handler: MockHandler(), accepts: methods)
     }
 }
 
 private struct MockHandler: WSHandler {
-    func makeFrames(for client: AsyncThrowingStream<WSFrame, Error>) async throws -> AsyncStream<WSFrame> {
+    func makeFrames(for client: AsyncThrowingStream<WSFrame, any Error>) async throws -> AsyncStream<WSFrame> {
         var iterator = client.makeAsyncIterator()
         return AsyncStream<WSFrame> {
             try? await iterator.next()

--- a/FlyingFox/Tests/WebSocket/AsyncStream+WSFrameTests.swift
+++ b/FlyingFox/Tests/WebSocket/AsyncStream+WSFrameTests.swift
@@ -53,7 +53,7 @@ final class WSFrameSequenceTests: XCTestCase {
 
     func testProtocolFrames_CatchErrors_AndCloseStream() async throws {
         var continuation: AsyncThrowingStream<WSFrame, Error>.Continuation!
-        let stream = AsyncThrowingStream<WSFrame, Error> {
+        let stream = AsyncThrowingStream<WSFrame, any Error> {
             continuation = $0
         }
 
@@ -76,7 +76,7 @@ extension WSFrame {
     static let pong = WSFrame.make(opcode: .pong)
 }
 
-extension AsyncThrowingStream where Element == WSFrame, Failure == Error {
+extension AsyncThrowingStream where Element == WSFrame, Failure == any Error {
     static func make(_ frames: [WSFrame]) -> Self {
         let bytes = ConsumingAsyncSequence(frames.flatMap(WSFrameEncoder.encodeFrame))
         return AsyncThrowingStream.decodingFrames(from: bytes)

--- a/FlyingFox/Tests/WebSocket/WSFrameValidatorTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSFrameValidatorTests.swift
@@ -95,7 +95,7 @@ final class WSFrameValidatorTests: XCTestCase {
 
 private extension WSFrameValidator {
 
-    static func validate(_ frames: [WSFrame]) async throws -> AsyncThrowingStream<WSFrame, Swift.Error> {
+    static func validate(_ frames: [WSFrame]) async throws -> AsyncThrowingStream<WSFrame, any Swift.Error> {
         var iterator = validateFrames(from: AsyncThrowingStream.make(frames)).makeAsyncIterator()
         return AsyncThrowingStream { try await iterator.next() }
     }

--- a/FlyingFox/Tests/WebSocket/WSHandlerTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSHandlerTests.swift
@@ -129,7 +129,7 @@ final class WSHandlerTests: XCTestCase {
 
 extension MessageFrameWSHandler {
 
-    static func make(handler: WSMessageHandler = Messages(),
+    static func make(handler: some WSMessageHandler = Messages(),
                      frameSize: Int = 1024) -> Self {
         MessageFrameWSHandler(handler: handler,
                               frameSize: frameSize)
@@ -140,7 +140,7 @@ extension MessageFrameWSHandler {
     }
 }
 
-private final class Messages: WSMessageHandler, @unchecked Sendable {
+final class Messages: WSMessageHandler, @unchecked Sendable {
 
     var input: AsyncStream<WSMessage>!
     var output: AsyncStream<WSMessage>.Continuation!

--- a/FlyingSocks/Sources/AsyncDataSequence.swift
+++ b/FlyingSocks/Sources/AsyncDataSequence.swift
@@ -105,10 +105,10 @@ private extension AsyncDataSequence {
     actor DataLoader {
         nonisolated fileprivate let count: Int
         nonisolated fileprivate let chunkSize: Int
-        private let iterator: AsyncDataIterator
+        private let iterator: any AsyncDataIterator
         private var state: State
 
-        init(count: Int, chunkSize: Int, iterator: AsyncDataIterator) {
+        init(count: Int, chunkSize: Int, iterator: some AsyncDataIterator) {
             self.count = count
             self.chunkSize = chunkSize
             self.iterator = iterator

--- a/FlyingSocks/Sources/AsyncSocket.swift
+++ b/FlyingSocks/Sources/AsyncSocket.swift
@@ -49,7 +49,7 @@ public protocol AsyncSocketPool: Sendable {
 public extension AsyncSocketPool where Self == SocketPool<Poll> {
 
     @available(*, unavailable, renamed: "client")
-    static var pollingClient: AsyncSocketPool {
+    static var pollingClient: Self {
         fatalError("use .client")
     }
 
@@ -63,9 +63,9 @@ public extension AsyncSocketPool where Self == SocketPool<Poll> {
 public struct AsyncSocket: Sendable {
 
     public let socket: Socket
-    let pool: AsyncSocketPool
+    let pool: any AsyncSocketPool
 
-    public init(socket: Socket, pool: AsyncSocketPool) throws {
+    public init(socket: Socket, pool: some AsyncSocketPool) throws {
         self.socket = socket
         self.pool = pool
         try socket.setFlags(.nonBlocking)
@@ -75,7 +75,7 @@ public struct AsyncSocket: Sendable {
         try await connected(to: address, pool: ClientPoolLoader.shared.getPool())
     }
 
-    public static func connected<A: SocketAddress>(to address: A,  pool: AsyncSocketPool) async throws -> Self {
+    public static func connected<A: SocketAddress>(to address: A,  pool: some AsyncSocketPool) async throws -> Self {
         let socket = try Socket(domain: Int32(address.makeStorage().ss_family), type: Socket.stream)
         let asyncSocket = try AsyncSocket(socket: socket, pool: pool)
         try await asyncSocket.connect(to: address)

--- a/FlyingSocks/Sources/CancellingContinuation.swift
+++ b/FlyingSocks/Sources/CancellingContinuation.swift
@@ -62,7 +62,7 @@ public struct CancellingContinuation<Success, Failure: Error>: Sendable {
     }
 
     public func resume(with result: Result<Success, Failure>) {
-        Task { await inner.resume(with: result.mapError { $0 as Error }) }
+        Task { await inner.resume(with: result.mapError { $0 as any Error }) }
     }
 
     public func cancel() {
@@ -73,8 +73,8 @@ public struct CancellingContinuation<Success, Failure: Error>: Sendable {
 extension CancellingContinuation {
 
     actor Inner {
-        private var continuation: UnsafeContinuation<Success, Error>?
-        private var result: Result<Success, Error>?
+        private var continuation: UnsafeContinuation<Success, any Error>?
+        private var result: Result<Success, any Error>?
         private var hasStarted: Bool = false
 
         func getValue() async throws -> Success {
@@ -88,7 +88,7 @@ extension CancellingContinuation {
             return try result.get()
         }
 
-        func resume(with result: Result<Success, Error>) {
+        func resume(with result: Result<Success, any Error>) {
             if let continuation = continuation {
                 self.continuation = nil
                 continuation.resume(with: result)

--- a/FlyingSocks/Sources/Logging+OSLog.swift
+++ b/FlyingSocks/Sources/Logging+OSLog.swift
@@ -41,26 +41,35 @@ public struct OSLogLogger: Logging, @unchecked Sendable {
         self.logger = logger
     }
 
-    public func logDebug(_ debug: String) {
-        logger.debug("\(debug, privacy: .public)")
+    public func logDebug(_ debug: @autoclosure () -> String) {
+        withoutActuallyEscaping(debug) { debug in
+            logger.debug("\(debug(), privacy: .public)")
+        }
     }
         
-    public func logInfo(_ info: String) {
-        logger.info("\(info, privacy: .public)")
+    public func logInfo(_ info: @autoclosure () -> String) {
+        withoutActuallyEscaping(info) { info in
+            logger.info("\(info(), privacy: .public)")
+        }
     }
 
-    public func logWarning(_ warning: String) {
-        logger.warning("\(warning, privacy: .public)")
+    public func logWarning(_ warning: @autoclosure () -> String) {
+        withoutActuallyEscaping(warning) { warning in
+            logger.warning("\(warning(), privacy: .public)")
+        }
     }
 
-    public func logError(_ error: String) {
-        logger.error("\(error, privacy: .public)")
+    public func logError(_ error: @autoclosure () -> String) {
+        withoutActuallyEscaping(error) { error in
+            logger.error("\(error(), privacy: .public)")
+        }
     }
     
-    public func logCritical(_ critical: String) {
-        logger.critical("\(critical, privacy: .public)")
+    public func logCritical(_ critical: @autoclosure () -> String) {
+        withoutActuallyEscaping(critical) { critical in
+            logger.error("\(critical(), privacy: .public)")
+        }
     }
-
 }
 
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, *)

--- a/FlyingSocks/Sources/Logging.swift
+++ b/FlyingSocks/Sources/Logging.swift
@@ -30,11 +30,11 @@
 //
 
 public protocol Logging: Sendable {
-    func logDebug(_ debug: String)
-    func logInfo(_ info: String)
-    func logWarning(_ warning: String)
-    func logError(_ error: String)
-    func logCritical(_ critical: String)
+    func logDebug(_ debug: @autoclosure () -> String)
+    func logInfo(_ info: @autoclosure () -> String)
+    func logWarning(_ warning: @autoclosure () -> String)
+    func logError(_ error: @autoclosure () -> String)
+    func logCritical(_ critical: @autoclosure () -> String)
 }
 
 public struct PrintLogger: Logging {
@@ -45,30 +45,50 @@ public struct PrintLogger: Logging {
         self.category = category
     }
 
-    public func logDebug(_ debug: String) {
-        Swift.print("[\(category)] debug: \(debug)")
+    public func logDebug(_ debug: @autoclosure () -> String) {
+        Swift.print("[\(category)] debug: \(debug())")
     }
     
-    public func logInfo(_ info: String) {
-        Swift.print("[\(category)] info: \(info)")
+    public func logInfo(_ info: @autoclosure () -> String) {
+        Swift.print("[\(category)] info: \(info())")
     }
 
-    public func logWarning(_ warning: String) {
-        Swift.print("[\(category)] warning: \(warning)")
+    public func logWarning(_ warning: @autoclosure () -> String) {
+        Swift.print("[\(category)] warning: \(warning())")
     }
     
-    public func logError(_ error: String) {
-        Swift.print("[\(category)] error: \(error)")
+    public func logError(_ error: @autoclosure () -> String) {
+        Swift.print("[\(category)] error: \(error())")
     }
     
-    public func logCritical(_ critical: String) {
-        Swift.print("[\(category)] critical: \(critical)")
+    public func logCritical(_ critical: @autoclosure () -> String) {
+        Swift.print("[\(category)] critical: \(critical())")
     }
+}
+
+public struct DisabledLogger: Logging {
+
+    public func logDebug(_ debug: @autoclosure () -> String) { }
+
+    public func logInfo(_ info: @autoclosure () -> String) { }
+
+    public func logWarning(_ warning: @autoclosure () -> String) { }
+
+    public func logError(_ error: @autoclosure () -> String) { }
+
+    public func logCritical(_ critical: @autoclosure () -> String) { }
 }
 
 public extension Logging where Self == PrintLogger {
 
     static func print(category: String) -> Self {
-        return PrintLogger(category: category)
+        PrintLogger(category: category)
+    }
+}
+
+public extension Logging where Self == DisabledLogger {
+
+    static var disabled: Self {
+        DisabledLogger()
     }
 }

--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -256,7 +256,7 @@ public struct Socket: Sendable, Hashable {
 }
 
 public extension Socket {
-    struct Flags: OptionSet {
+    struct Flags: OptionSet, Sendable {
         public var rawValue: Int32
 
         public init(rawValue: Int32) {
@@ -269,7 +269,7 @@ public extension Socket {
 
 public extension Socket {
 
-    enum Event {
+    enum Event: Sendable {
         case read
         case write
     }

--- a/FlyingSocks/Sources/SocketAddress.swift
+++ b/FlyingSocks/Sources/SocketAddress.swift
@@ -113,7 +113,7 @@ public extension SocketAddress {
 
 extension Socket {
 
-    public enum Address: Hashable {
+    public enum Address: Sendable, Hashable {
         case ip4(String, port: UInt16)
         case ip6(String, port: UInt16)
         case unix(String)

--- a/FlyingSocks/Sources/SocketPool+Poll.swift
+++ b/FlyingSocks/Sources/SocketPool+Poll.swift
@@ -32,8 +32,12 @@
 import Foundation
 
 public extension AsyncSocketPool where Self == SocketPool<Poll> {
-    static func poll(interval: Poll.Interval = .seconds(0.01), logger: Logging? = nil) -> SocketPool<Poll> {
-        SocketPool(queue: Poll(interval: interval, logger: logger), logger: logger)
+    static func poll(interval: Poll.Interval = .seconds(0.01), logger: some Logging = .disabled) -> SocketPool<Poll> {
+        .init(interval: interval, logger: logger)
+    }
+
+    private init(interval: Poll.Interval = .seconds(0.01), logger: some Logging) {
+        self.init(queue:  Poll(interval: interval, logger: logger), logger: logger)
     }
 }
 
@@ -42,7 +46,7 @@ public struct Poll: EventQueue {
     private(set) var entries: Set<Entry>
     private var isOpen: Bool = false
     private let interval: Interval
-    private let logger: Logging?
+    private let logger: any Logging
 
     struct Entry: Hashable {
         var file: Socket.FileDescriptor
@@ -54,7 +58,7 @@ public struct Poll: EventQueue {
         case seconds(TimeInterval)
     }
 
-    public init(interval: Interval, logger: Logging? = nil) {
+    public init(interval: Interval, logger: some Logging = .disabled) {
         self.entries = []
         self.interval = interval
         self.logger = logger

--- a/FlyingSocks/Sources/SocketPool+ePoll.swift
+++ b/FlyingSocks/Sources/SocketPool+ePoll.swift
@@ -33,8 +33,12 @@
 import CSystemLinux
 
 public extension AsyncSocketPool where Self == SocketPool<ePoll> {
-    static func ePoll(maxEvents limit: Int = 20, logger: Logging? = nil) -> SocketPool<ePoll> {
-        SocketPool(queue: FlyingSocks.ePoll(maxEvents: limit, logger: logger), logger: logger)
+    static func ePoll(maxEvents limit: Int = 20, logger: some Logging = .disabled) -> SocketPool<ePoll> {
+        .init(maxEvents: limit, logger: logger)
+    }
+
+    private init(maxEvents limit: Int, logger: some Logging = .disabled) {
+        self.init(queue: FlyingSocks.ePoll(maxEvents: limit, logger: logger), logger: logger)
     }
 }
 
@@ -43,9 +47,9 @@ public struct ePoll: EventQueue {
     private(set) var file: Socket.FileDescriptor
     private(set) var existing: [Socket.FileDescriptor: Socket.Events]
     private let eventsLimit: Int
-    private let logger: Logging?
+    private let logger: any Logging
 
-    public init(maxEvents limit: Int, logger: Logging? = nil) {
+    public init(maxEvents limit: Int, logger: some Logging = .disabled) {
         self.file = .invalid
         self.existing = [:]
         self.eventsLimit = limit

--- a/FlyingSocks/Sources/SocketPool+kQueue.swift
+++ b/FlyingSocks/Sources/SocketPool+kQueue.swift
@@ -33,8 +33,12 @@
 import Darwin
 
 public extension AsyncSocketPool where Self == SocketPool<kQueue> {
-    static func kQueue(maxEvents limit: Int = 20, logger: Logging? = nil) -> SocketPool<kQueue> {
-        SocketPool(queue: FlyingSocks.kQueue(maxEvents: limit, logger: logger), logger: logger)
+    static func kQueue(maxEvents limit: Int = 20, logger: some Logging = .disabled) -> SocketPool<kQueue> {
+        .init(maxEvents: limit, logger: logger)
+    }
+
+    private init(maxEvents limit: Int, logger: some Logging = .disabled) {
+        self.init(queue: FlyingSocks.kQueue(maxEvents: limit, logger: logger), logger: logger)
     }
 }
 
@@ -43,9 +47,9 @@ public struct kQueue: EventQueue {
     private(set) var file: Socket.FileDescriptor
     private(set) var existing: [Socket.FileDescriptor: Socket.Events]
     private let eventsLimit: Int
-    private let logger: Logging?
+    private let logger: any Logging
 
-    public init(maxEvents limit: Int, logger: Logging? = nil) {
+    public init(maxEvents limit: Int, logger: some Logging = .disabled) {
         self.file = .invalid
         self.existing = [:]
         self.eventsLimit = limit

--- a/FlyingSocks/Sources/Task+Timeout.swift
+++ b/FlyingSocks/Sources/Task+Timeout.swift
@@ -55,7 +55,7 @@ public struct TimeoutError: LocalizedError {
 @_spi(Private)
 public extension Task {
 
-    enum CancellationPolicy {
+    enum CancellationPolicy: Sendable {
         /// Cancels the task when the task retrieving the value is cancelled
         case whenParentIsCancelled
 

--- a/FlyingSocks/Tests/AsyncSocketTests.swift
+++ b/FlyingSocks/Tests/AsyncSocketTests.swift
@@ -164,7 +164,7 @@ extension AsyncSocket {
         try await make(pool: .client)
     }
 
-    static func makeListening(pool: AsyncSocketPool) throws -> AsyncSocket {
+    static func makeListening(pool: some AsyncSocketPool) throws -> AsyncSocket {
         let address = sockaddr_un.unix(path: "foxsocks")
         try? Socket.unlink(address)
         let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
@@ -174,7 +174,7 @@ extension AsyncSocket {
         return try AsyncSocket(socket: socket, pool: pool)
     }
 
-    static func make(pool: AsyncSocketPool) throws -> AsyncSocket {
+    static func make(pool: some AsyncSocketPool) throws -> AsyncSocket {
         let socket = try Socket(domain: AF_UNIX, type: Socket.stream)
         return try AsyncSocket(socket: socket, pool: pool)
     }
@@ -183,7 +183,7 @@ extension AsyncSocket {
         try await makePair(pool: .client)
     }
 
-    static func makePair(pool: AsyncSocketPool) throws -> (AsyncSocket, AsyncSocket) {
+    static func makePair(pool: some AsyncSocketPool) throws -> (AsyncSocket, AsyncSocket) {
         let (file1, file2) = Socket.socketpair(AF_UNIX, Socket.stream, 0)
         guard file1.rawValue > -1, file2.rawValue > -1 else {
             throw SocketError.makeFailed("SocketPair")

--- a/FlyingSocks/Tests/CancellingContinuationTests.swift
+++ b/FlyingSocks/Tests/CancellingContinuationTests.swift
@@ -77,7 +77,7 @@ final class CancellingContinuationTests: XCTestCase {
     }
 
     func testResumeIsReturned() async {
-        let continuation = CancellingContinuation<Void, Error>()
+        let continuation = CancellingContinuation<Void, any Error>()
 
         let task = Task { try await continuation.value }
         continuation.resume()
@@ -87,7 +87,7 @@ final class CancellingContinuationTests: XCTestCase {
     }
 
     func testErrorIsReturned() async {
-        let continuation = CancellingContinuation<String, Error>()
+        let continuation = CancellingContinuation<String, any Error>()
 
         let task = Task { try await continuation.value }
         continuation.resume(throwing: SocketError.disconnected)

--- a/FlyingSocks/Tests/SocketPoolTests.swift
+++ b/FlyingSocks/Tests/SocketPoolTests.swift
@@ -52,7 +52,7 @@ final class SocketPoolTests: XCTestCase {
 #endif
 
     func testPoll() {
-        let pool: AsyncSocketPool = .poll()
+        let pool: some AsyncSocketPool = .poll()
         XCTAssertTrue(type(of: pool) == SocketPool<Poll>.self)
     }
 
@@ -68,7 +68,7 @@ final class SocketPoolTests: XCTestCase {
     func testQueueRun_ThrowsError_WhenNotReady() async throws {
         let pool = SocketPool.make()
 
-        await AsyncAssertThrowsError(try await pool.run(), of: Error.self)
+        await AsyncAssertThrowsError(try await pool.run(), of: (any Error).self)
     }
 
     func testSuspendedSockets_ThrowError_WhenCancelled() async throws {
@@ -249,11 +249,11 @@ private extension SocketPool where Queue == MockEventQueue  {
     }
 }
 
-final class MockEventQueue: EventQueue {
+final class MockEventQueue: EventQueue, @unchecked Sendable {
 
     private var isWaiting: Bool = false
     private let semaphore = DispatchSemaphore(value: 0)
-    private var result: Result<[EventNotification], Error>?
+    private var result: Result<[EventNotification], any Error>?
 
     private(set) var state: State?
 
@@ -269,7 +269,7 @@ final class MockEventQueue: EventQueue {
         }
     }
 
-    func sendResult(throwing error: Error) {
+    func sendResult(throwing error: some Error) {
         result = .failure(error)
         if isWaiting {
             semaphore.signal()

--- a/FlyingSocks/Tests/Task+TimeoutTests.swift
+++ b/FlyingSocks/Tests/Task+TimeoutTests.swift
@@ -46,7 +46,7 @@ final class TaskTimeoutTests: XCTestCase {
 
     func testTimeoutThrowsError_WhenTimeoutExpires() async {
         // given
-        let task = Task<Void, Error>(timeout: 0.5) {
+        let task = Task<Void, any Error>(timeout: 0.5) {
             try? await Task.sleep(seconds: 10)
         }
 
@@ -146,7 +146,7 @@ final class TaskTimeoutTests: XCTestCase {
 
 @_spi(Private) import func FlyingSocks.withThrowingTimeout
 
-extension Task where Success: Sendable, Failure == Error {
+extension Task where Success: Sendable, Failure == any Error {
 
     // Start a new Task with a timeout.
     init(priority: TaskPriority? = nil, timeout: TimeInterval, operation: @escaping @Sendable () async throws -> Success) {

--- a/FlyingSocks/Tests/XCTest+Extension.swift
+++ b/FlyingSocks/Tests/XCTest+Extension.swift
@@ -86,9 +86,9 @@ func AsyncAssertThrowsError<T>(_ expression: @autoclosure () async throws -> T,
                                _ message: @autoclosure () -> String = "",
                                file: StaticString = #filePath,
                                line: UInt = #line,
-                               _ errorHandler: (_ error: Error) -> Void = { _ in }) async {
+                               _ errorHandler: (_ error: any Error) -> Void = { _ in }) async {
     await AsyncAssertThrowsError(try await expression(),
-                                 of: Error.self,
+                                 of: (any Error).self,
                                  message(),
                                  file: file,
                                  line: line,
@@ -119,7 +119,7 @@ func AsyncAssertNotNil<T>(_ expression: @autoclosure () async throws -> T?,
     XCTAssertNotNil(try result.get(), message(), file: file, line: line)
 }
 
-private extension Result where Failure == Error {
+private extension Result where Failure == any Error {
     init(catching body: () async throws -> Success) async {
         do {
             self = .success(try await body())

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -21,8 +21,7 @@ let package = Package(
         .target(
             name: "FlyingFox",
             dependencies: ["FlyingSocks"],
-            path: "FlyingFox/Sources",
-            swiftSettings: .upcomingFeatures
+            path: "FlyingFox/Sources"
         ),
         .testTarget(
             name: "FlyingFoxTests",
@@ -30,14 +29,12 @@ let package = Package(
             path: "FlyingFox/Tests",
             resources: [
                 .copy("Stubs")
-            ],
-            swiftSettings: .upcomingFeatures
+            ]
         ),
         .target(
             name: "FlyingSocks",
             dependencies: [.target(name: "CSystemLinux", condition: .when(platforms: [.linux]))],
-            path: "FlyingSocks/Sources",
-            swiftSettings: .upcomingFeatures
+            path: "FlyingSocks/Sources"
         ),
         .testTarget(
             name: "FlyingSocksTests",
@@ -45,8 +42,7 @@ let package = Package(
             path: "FlyingSocks/Tests",
             resources: [
                 .copy("Resources")
-            ],
-            swiftSettings: .upcomingFeatures
+            ]
         ),
         .target(
              name: "CSystemLinux",
@@ -54,13 +50,3 @@ let package = Package(
         )
     ]
 )
-
-extension Array where Element == SwiftSetting {
-
-    static var upcomingFeatures: [SwiftSetting] {
-        [
-            .enableUpcomingFeature("ExistentialAny"),
-            //.enableExperimentalFeature("StrictConcurrency")
-        ]
-    }
-}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build](https://github.com/swhitty/FlyingFox/actions/workflows/build.yml/badge.svg)](https://github.com/swhitty/FlyingFox/actions/workflows/build.yml)
 [![Codecov](https://codecov.io/gh/swhitty/FlyingFox/graphs/badge.svg)](https://codecov.io/gh/swhitty/FlyingFox)
 [![Platforms](https://img.shields.io/badge/platforms-iOS%20|%20Mac%20|%20tvOS%20|%20Linux%20|%20Windows-lightgray.svg)](https://github.com/swhitty/FlyingFox/blob/main/Package.swift)
-[![Swift 5.9](https://img.shields.io/badge/swift-5.7%20–%205.9-red.svg?style=flat)](https://developer.apple.com/swift)
+[![Swift 5.10](https://img.shields.io/badge/swift-5.7%20–%205.10-red.svg?style=flat)](https://developer.apple.com/swift)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://opensource.org/licenses/MIT)
 [![Twitter](https://img.shields.io/badge/twitter-@simonwhitty-blue.svg)](http://twitter.com/simonwhitty)
 

--- a/docker-run-tests.sh
+++ b/docker-run-tests.sh
@@ -5,5 +5,5 @@ set -eu
 docker run -it \
   --rm \
   --mount src="$(pwd)",target=/flyingfox,type=bind \
-  swiftlang/swift:nightly-5.9-jammy \
+  swift:5.10-jammy \
   /usr/bin/swift test --package-path /flyingfox


### PR DESCRIPTION
Adds support for Swift 5.10 fixing some concurrency warnings.

Enables `.enableUpcomingFeature("ExistentialAny")`

### protocol Logging
A breaking change has been made to `protocol Logging` which impacts those who have implemented custom loggers.  `@autoclosure` is now used for log messages, these closures are only executed if required.

A new `DisabledLogger` has been added removing the need for `(any Logging)?`. The disabled logger does not execute the message closure and therefore is a no-op.
```swift
let logger: some Logging = .disabled
```