### PR TITLE
Remove backported method

### DIFF
--- a/FlyingFox/Sources/Handlers/ProxyHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/ProxyHTTPHandler.swift
@@ -48,7 +48,7 @@ public struct ProxyHTTPHandler: HTTPHandler, Sendable {
 
     public func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
         let req = try await makeURLRequest(for: request)
-        let (data, response) = try await session.getData(for: req)
+        let (data, response) = try await session.data(for: req)
         return makeResponse(for: response as! HTTPURLResponse, data: data)
     }
 

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -323,7 +323,7 @@ final class HTTPServerTests: XCTestCase {
         let port = try await startServerWithPort(server)
 
         let request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)")!)
-        let (_, response) = try await URLSession.shared.makeData(for: request)
+        let (_, response) = try await URLSession.shared.data(for: request)
 
         XCTAssertEqual(
             (response as? HTTPURLResponse)?.statusCode,

--- a/FlyingFox/Tests/URLSession+AsyncTests.swift
+++ b/FlyingFox/Tests/URLSession+AsyncTests.swift
@@ -40,7 +40,7 @@ final class URLSessionAsyncTests: XCTestCase {
 
     func testURLSession_MakesRequest() async throws {
         let request = URLRequest(url: URL(string: "https://pie.dev/status/208")!)
-        let (_, response) = try await URLSession.shared.getData(for: request, forceFallback: false)
+        let (_, response) = try await URLSession.shared.data(for: request)
 
         XCTAssertEqual(
             (response as! HTTPURLResponse).statusCode,
@@ -48,40 +48,16 @@ final class URLSessionAsyncTests: XCTestCase {
         )
     }
 
-    func testURLSessionFallback_MakesRequest() async throws {
-        let request = URLRequest(url: URL(string: "https://pie.dev/status/208")!)
-        let (_, response) = try await URLSession.shared.getData(for: request, forceFallback: true)
-
-        XCTAssertEqual(
-            (response as! HTTPURLResponse).statusCode,
-            208
-        )
-    }
-
-    func testURLSessionFallback_ReturnsError() async throws {
+    func testURLSession_ReturnsError() async throws {
         let request = URLRequest(url: URL(string: "https://flying.fox.invalid/")!)
-        await AsyncAssertThrowsError(try await URLSession.shared.getData(for: request, forceFallback: true), of: URLError.self)
+        await AsyncAssertThrowsError(try await URLSession.shared.data(for: request), of: URLError.self)
     }
 
     func testURLSession_CancelsRequest() async throws {
         let request = URLRequest(url: URL(string: "https://httpstat.us/200?sleep=10000")!)
 
         let task = Task {
-            _ = try await URLSession.shared.getData(for: request)
-        }
-
-        task.cancel()
-
-        await AsyncAssertThrowsError(try await task.value, of: URLError.self) {
-            XCTAssertEqual($0.code, .cancelled)
-        }
-    }
-
-    func testURLSessionFallback_CancelsRequest() async throws {
-        let request = URLRequest(url: URL(string: "https://httpstat.us/200?sleep=10000")!)
-
-        let task = Task {
-            _ = try await URLSession.shared.getData(for: request, forceFallback: true)
+            _ = try await URLSession.shared.data(for: request)
         }
 
         task.cancel()

--- a/FlyingSocks/Sources/AllocatedLock.swift
+++ b/FlyingSocks/Sources/AllocatedLock.swift
@@ -1,0 +1,187 @@
+//
+//  AllocatedLock.swift
+//  AllocatedLock
+//
+//  Created by Simon Whitty on 10/04/2023.
+//  Copyright 2023 Simon Whitty
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/AllocatedLock
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+// Backports the Swift interface around os_unfair_lock_t available in recent Darwin platforms
+//
+@_spi(Private)
+public struct AllocatedLock<State>: @unchecked Sendable {
+
+    @usableFromInline
+    let storage: Storage
+
+    public init(initialState: State) {
+        self.storage = Storage(initialState: initialState)
+    }
+
+    @inlinable
+    public func withLock<R>(_ body: @Sendable (inout State) throws -> R) rethrows -> R where R: Sendable {
+        storage.lock()
+        defer { storage.unlock() }
+        return try body(&storage.state)
+    }
+}
+
+@_spi(Private)
+public extension AllocatedLock where State == Void {
+
+    init() {
+        self.storage = Storage(initialState: ())
+    }
+
+    @inlinable @available(*, noasync)
+    func lock() {
+        storage.lock()
+    }
+
+    @inlinable @available(*, noasync)
+    func unlock() {
+        storage.unlock()
+    }
+
+    @inlinable
+    func withLock<R>(_ body: @Sendable () throws -> R) rethrows -> R where R: Sendable {
+        storage.lock()
+        defer { storage.unlock() }
+        return try body()
+    }
+}
+
+#if canImport(Darwin)
+
+import struct os.os_unfair_lock_t
+import struct os.os_unfair_lock
+import func os.os_unfair_lock_lock
+import func os.os_unfair_lock_unlock
+
+extension AllocatedLock {
+    @usableFromInline
+    final class Storage {
+        private let _lock: os_unfair_lock_t
+
+        @usableFromInline
+        var state: State
+
+        init(initialState: State) {
+            self._lock = .allocate(capacity: 1)
+            self._lock.initialize(to: os_unfair_lock())
+            self.state = initialState
+        }
+
+        @usableFromInline
+        func lock() {
+            os_unfair_lock_lock(_lock)
+        }
+
+        @usableFromInline
+        func unlock() {
+            os_unfair_lock_unlock(_lock)
+        }
+
+        deinit {
+            self._lock.deinitialize(count: 1)
+            self._lock.deallocate()
+        }
+    }
+}
+
+#elseif canImport(Glibc)
+
+@_implementationOnly import Glibc
+
+extension AllocatedLock {
+    @usableFromInline
+    final class Storage {
+        private let _lock: UnsafeMutablePointer<pthread_mutex_t>
+
+        @usableFromInline
+        var state: State
+
+        init(initialState: State) {
+            var attr = pthread_mutexattr_t()
+            pthread_mutexattr_init(&attr)
+            self._lock = .allocate(capacity: 1)
+            let err = pthread_mutex_init(self._lock, &attr)
+            precondition(err == 0, "pthread_mutex_init error: \(err)")
+            self.state = initialState
+        }
+
+        @usableFromInline
+        func lock() {
+            let err = pthread_mutex_lock(_lock)
+            precondition(err == 0, "pthread_mutex_lock error: \(err)")
+        }
+
+        @usableFromInline
+        func unlock() {
+            let err = pthread_mutex_unlock(_lock)
+            precondition(err == 0, "pthread_mutex_unlock error: \(err)")
+        }
+
+        deinit {
+            let err = pthread_mutex_destroy(self._lock)
+            precondition(err == 0, "pthread_mutex_destroy error: \(err)")
+            self._lock.deallocate()
+        }
+    }
+}
+
+#elseif canImport(WinSDK)
+
+@_implementationOnly import ucrt
+@_implementationOnly import WinSDK
+
+extension AllocatedLock {
+    @usableFromInline
+    final class Storage {
+        private let _lock: UnsafeMutablePointer<SRWLOCK>
+
+        @usableFromInline
+        var state: State
+
+        init(initialState: State) {
+            self._lock = .allocate(capacity: 1)
+            InitializeSRWLock(self._lock)
+            self.state = initialState
+        }
+
+        @usableFromInline
+        func lock() {
+            AcquireSRWLockExclusive(_lock)
+        }
+
+        @usableFromInline
+        func unlock() {
+            ReleaseSRWLockExclusive(_lock)
+        }
+    }
+}
+
+#endif

--- a/FlyingSocks/Tests/AllocatedLockTests.swift
+++ b/FlyingSocks/Tests/AllocatedLockTests.swift
@@ -1,0 +1,92 @@
+//
+//  AllocatedLockTests.swift
+//  AllocatedLock
+//
+//  Created by Simon Whitty on 10/04/2023.
+//  Copyright 2023 Simon Whitty
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/AllocatedLock
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@_spi(Private) import struct FlyingSocks.AllocatedLock
+import XCTest
+
+final class AllocatedLockTests: XCTestCase {
+
+    func testLockState_IsProtected() async {
+        let state = AllocatedLock<Int>(initialState: 0)
+
+        let total = await withTaskGroup(of: Void.self) { group in
+            for i in 1...1000 {
+                group.addTask {
+                    state.withLock { $0 += i }
+                }
+            }
+            await group.waitForAll()
+            return state.withLock { $0 }
+        }
+
+        XCTAssertEqual(total, 500500)
+    }
+
+    func testLock_ReturnsValue() async {
+        let lock = AllocatedLock()
+        let value = lock.withLock { true }
+        XCTAssertTrue(value)
+    }
+
+    func testLock_Blocks() async {
+        let lock = AllocatedLock()
+
+        Task { @MainActor in
+            lock.unsafeLock()
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            lock.unsafeUnlock()
+        }
+
+        try? await Task.sleep(nanoseconds: 500_000)
+
+        let results = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 5_000_000)
+                return true
+            }
+            group.addTask {
+                lock.unsafeLock()
+                lock.unsafeUnlock()
+                return false
+            }
+            let first = await group.next()!
+            let second = await group.next()!
+            return [first, second]
+        }
+        XCTAssertEqual(results, [true, false])
+    }
+}
+
+// sidestep warning: unavailable from asynchronous contexts
+extension AllocatedLock where State == Void {
+    func unsafeLock() { lock() }
+    func unsafeUnlock() { unlock() }
+}


### PR DESCRIPTION
Xcode 14.1 [@backdeploy](https://github.com/apple/swift-evolution/blob/main/proposals/0376-function-back-deployment.md)'s [`URLSession.data(for:delegate:)`](https://developer.apple.com/documentation/foundation/urlsession/3767352-data) to iOS 13 so the fallback method can now be compiled only on Linux/Windows.  macOS builds can always use the Foundation version.

Adds `@spi(Private)` version of [AllocatedLock](https://github.com/swhitty/AllocatedLock) to FlyingSocks making a fast cross platform lock implementation available for all platforms.