### PR TITLE
Introduce EventQueue.stop()

### DIFF
--- a/FlyingSocks/Sources/SocketPool+Poll.swift
+++ b/FlyingSocks/Sources/SocketPool+Poll.swift
@@ -69,9 +69,13 @@ public struct Poll: EventQueue {
         isOpen = true
     }
 
-    public mutating func close() {
+    public mutating func stop() {
         entries = []
         isOpen = false
+    }
+
+    public mutating func close() {
+        // stop closes
     }
 
     public mutating func addEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {

--- a/FlyingSocks/Sources/SocketPool+ePoll.swift
+++ b/FlyingSocks/Sources/SocketPool+ePoll.swift
@@ -61,13 +61,17 @@ public struct ePoll: EventQueue {
         self.file = try Self.makeQueue()
     }
 
-    public mutating func close() throws {
+    public mutating func stop() throws {
         existing = [:]
         guard file != .invalid else {
             throw SocketError.disconnected
         }
         defer { file = .invalid }
         try Self.closeQueue(file: file)
+    }
+
+    public mutating func close() throws {
+        // should really close file here
     }
 
     public mutating func addEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {

--- a/FlyingSocks/Sources/SocketPool+kQueue.swift
+++ b/FlyingSocks/Sources/SocketPool+kQueue.swift
@@ -61,13 +61,17 @@ public struct kQueue: EventQueue {
         self.file = try Self.makeQueue()
     }
 
-    public mutating func close() throws {
+    public mutating func stop() throws {
         existing = [:]
         guard file != .invalid else {
             throw SocketError.disconnected
         }
         defer { file = .invalid }
         try Self.closeQueue(file: file)
+    }
+
+    public mutating func close() throws {
+        // stop closes
     }
 
     public mutating func addEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {

--- a/FlyingSocks/Tests/SocketPool+PollTests.swift
+++ b/FlyingSocks/Tests/SocketPool+PollTests.swift
@@ -58,7 +58,7 @@ final class PollTests: XCTestCase {
 
     func testAddingEventWhenNotOpen_ThrowsError() {
         var queue = Poll.make()
-        queue.close()
+        queue.stop()
 
         XCTAssertThrowsError(
             try queue.addEvents(.read, for: .validMock)
@@ -67,7 +67,7 @@ final class PollTests: XCTestCase {
 
     func testRemovingEventWhenNotOpen_ThrowsError() {
         var queue = Poll.make()
-        queue.close()
+        queue.stop()
 
         XCTAssertThrowsError(
             try queue.removeEvents(.read, for: .validMock)
@@ -212,7 +212,7 @@ final class PollTests: XCTestCase {
 
     func testGetEventsWhenNotReady_ThrowsError() async {
         var queue = Poll.make()
-        queue.close()
+        queue.stop()
 
         await AsyncAssertThrowsError(
             try await queue.getEvents()

--- a/FlyingSocks/Tests/SocketPool+kQueueTests.swift
+++ b/FlyingSocks/Tests/SocketPool+kQueueTests.swift
@@ -37,7 +37,7 @@ final class kQueueTests: XCTestCase {
 
     func testQueueCloses() throws {
         var queue = try kQueue.make()
-        XCTAssertNoThrow(try queue.close())
+        XCTAssertNoThrow(try queue.stop())
     }
 
     func testQueueThrowsError_Closes() throws {
@@ -199,7 +199,7 @@ final class kQueueTests: XCTestCase {
         let (s1, _) = try Socket.makeNonBlockingPair()
         try queue.addEvents([.read], for: s1.file)
 
-        try queue.close()
+        try queue.stop()
         await AsyncAssertThrowsError(try await queue.getEvents())
     }
 }


### PR DESCRIPTION
It is not safe to close ePOLL queue concurrently while waiting for events, it should be stopped first.  A future PR will add that logic.

`stop()` is added in place of existing `close()`