### PR TITLE
Change HTTPRoute.method to be of type HTTPMethod

### DIFF
--- a/FlyingFox/Sources/HTTPMethod.swift
+++ b/FlyingFox/Sources/HTTPMethod.swift
@@ -46,6 +46,10 @@ public struct HTTPMethod: Sendable, RawRepresentable, Hashable, ExpressibleByStr
 }
 
 public extension HTTPMethod {
+    func hash(into hasher: inout Hasher) {
+        rawValue.uppercased().hash(into: &hasher)
+    }
+
     static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.rawValue.uppercased() == rhs.rawValue.uppercased()
     }

--- a/FlyingFox/Sources/HTTPMethod.swift
+++ b/FlyingFox/Sources/HTTPMethod.swift
@@ -29,7 +29,9 @@
 //  SOFTWARE.
 //
 
-public struct HTTPMethod: Sendable, RawRepresentable, Hashable {
+public struct HTTPMethod: Sendable, RawRepresentable, Hashable, ExpressibleByStringLiteral {
+    public typealias StringLiteralType = String
+
     public var rawValue: String
 
     public init(rawValue: String) {
@@ -39,16 +41,35 @@ public struct HTTPMethod: Sendable, RawRepresentable, Hashable {
     public init(_ rawValue: String) {
         self.init(rawValue: rawValue)
     }
+
+    public init(stringLiteral value: String) {
+        self.init(rawValue: value.uppercased())
+    }
 }
 
 public extension HTTPMethod {
-    static let GET     = HTTPMethod("GET")
-    static let POST    = HTTPMethod("POST")
-    static let PUT     = HTTPMethod("PUT")
-    static let DELETE  = HTTPMethod("DELETE")
-    static let PATCH   = HTTPMethod("PATCH")
-    static let HEAD    = HTTPMethod("HEAD")
-    static let OPTIONS = HTTPMethod("OPTIONS")
-    static let CONNECT = HTTPMethod("CONNECT")
-    static let TRACE   = HTTPMethod("TRACE")
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.rawValue.uppercased() == rhs.rawValue.uppercased()
+    }
+
+    static func ~= (lhs: Self, rhs: Self) -> Bool {
+        if lhs == .ANY || rhs == .ANY {
+            return true
+        }
+
+        return lhs == rhs
+    }
+}
+
+public extension HTTPMethod {
+    internal static let ANY  = HTTPMethod("*")
+    static let GET           = HTTPMethod("GET")
+    static let POST          = HTTPMethod("POST")
+    static let PUT           = HTTPMethod("PUT")
+    static let DELETE        = HTTPMethod("DELETE")
+    static let PATCH         = HTTPMethod("PATCH")
+    static let HEAD          = HTTPMethod("HEAD")
+    static let OPTIONS       = HTTPMethod("OPTIONS")
+    static let CONNECT       = HTTPMethod("CONNECT")
+    static let TRACE         = HTTPMethod("TRACE")
 }

--- a/FlyingFox/Sources/HTTPMethod.swift
+++ b/FlyingFox/Sources/HTTPMethod.swift
@@ -30,8 +30,6 @@
 //
 
 public struct HTTPMethod: Sendable, RawRepresentable, Hashable, ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-
     public var rawValue: String
 
     public init(rawValue: String) {
@@ -39,7 +37,7 @@ public struct HTTPMethod: Sendable, RawRepresentable, Hashable, ExpressibleByStr
     }
 
     public init(_ rawValue: String) {
-        self.init(rawValue: rawValue)
+        self.init(rawValue: rawValue.uppercased())
     }
 
     public init(stringLiteral value: String) {
@@ -51,25 +49,30 @@ public extension HTTPMethod {
     static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.rawValue.uppercased() == rhs.rawValue.uppercased()
     }
-
-    static func ~= (lhs: Self, rhs: Self) -> Bool {
-        if lhs == .ANY || rhs == .ANY {
-            return true
-        }
-
-        return lhs == rhs
-    }
 }
 
 public extension HTTPMethod {
-    internal static let ANY  = HTTPMethod("*")
-    static let GET           = HTTPMethod("GET")
-    static let POST          = HTTPMethod("POST")
-    static let PUT           = HTTPMethod("PUT")
-    static let DELETE        = HTTPMethod("DELETE")
-    static let PATCH         = HTTPMethod("PATCH")
-    static let HEAD          = HTTPMethod("HEAD")
-    static let OPTIONS       = HTTPMethod("OPTIONS")
-    static let CONNECT       = HTTPMethod("CONNECT")
-    static let TRACE         = HTTPMethod("TRACE")
+    internal static let sortedMethods = [
+        HTTPMethod.GET,
+        .POST,
+        .PUT,
+        .DELETE,
+        .PATCH,
+        .HEAD,
+        .OPTIONS,
+        .CONNECT,
+        .TRACE
+    ]
+
+    internal static let allMethods = Set(HTTPMethod.sortedMethods)
+
+    static let GET     = HTTPMethod("GET")
+    static let POST    = HTTPMethod("POST")
+    static let PUT     = HTTPMethod("PUT")
+    static let DELETE  = HTTPMethod("DELETE")
+    static let PATCH   = HTTPMethod("PATCH")
+    static let HEAD    = HTTPMethod("HEAD")
+    static let OPTIONS = HTTPMethod("OPTIONS")
+    static let CONNECT = HTTPMethod("CONNECT")
+    static let TRACE   = HTTPMethod("TRACE")
 }

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -32,23 +32,33 @@
 import Foundation
 
 public struct HTTPRoute: Sendable {
-    public var method: HTTPMethod
+    public var methods: Set<HTTPMethod>
     public var path: [Component]
     public var query: [QueryItem]
     public var headers: [HTTPHeader: Component]
     public var body: (any HTTPBodyPattern)?
 
-    public init(_ string: String, headers: [HTTPHeader: String] = [:], body: (any HTTPBodyPattern)? = nil) {
-        let comps = Self.components(for: string)
-        self.init(method: comps.method, path: comps.path, headers: headers, body: body)
+    public init(
+        methods: Set<HTTPMethod>,
+        path: String,
+        headers: [HTTPHeader: String] = [:],
+        body: (any HTTPBodyPattern)? = nil
+    ) {
+        self.methods = methods
+
+        let comps = HTTPRoute.readComponents(from: path)
+        self.path = comps.path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map { Component(String($0)) }
+        self.query = comps.query.map {
+            QueryItem(name: $0.name, value: Component($0.value))
+        }
+        self.headers = headers.mapValues(Component.init)
+        self.body = body
     }
 
-    public init(method: HTTPMethod, path: String, headers: [HTTPHeader: String] = [:], body: (any HTTPBodyPattern)? = nil) {
-        self.init(method: method.rawValue, path: path, headers: headers, body: body)
-    }
-
-    init(method: String, path: String, headers: [HTTPHeader: String], body: (any HTTPBodyPattern)?) {
-        self.method = HTTPMethod(method)
+    init(methods: String, path: String, headers: [HTTPHeader: String], body: (any HTTPBodyPattern)?) {
+        self.methods = Self.methods(for: methods)
 
         let comps = HTTPRoute.readComponents(from: path)
         self.path = comps.path
@@ -73,6 +83,52 @@ public struct HTTPRoute: Sendable {
                 self = .caseInsensitive(string)
             }
         }
+    }
+
+    // MARK: Convenience Initializers
+
+    public init<HTTPMethods: Collection>(
+        methods: HTTPMethods,
+        path: String,
+        headers: [HTTPHeader: String] = [:],
+        body: (
+            any HTTPBodyPattern
+        )? = nil
+    ) where HTTPMethods.Element == HTTPMethod {
+        self.init(
+            methods: Set(methods),
+            path: path,
+            headers: headers,
+            body: body
+        )
+    }
+
+    public init(
+        method: HTTPMethod,
+        path: String,
+        headers: [HTTPHeader: String] = [:],
+        body: (any HTTPBodyPattern)? = nil
+    ) {
+        self.init(
+            methods: [method],
+            path: path,
+            headers: headers,
+            body: body
+        )
+    }
+
+    public init(
+        _ string: String,
+        headers: [HTTPHeader: String] = [:],
+        body: (any HTTPBodyPattern)? = nil
+    ) {
+        let comps = Self.components(for: string)
+        self.init(
+            methods: comps.methods,
+            path: comps.path,
+            headers: headers,
+            body: body
+        )
     }
 
     public struct QueryItem: Sendable, Equatable {
@@ -124,7 +180,7 @@ public extension HTTPRoute {
               patternMatch(body: request.bodySequence) else { return false }
 
         let nodes = request.path.split(separator: "/", omittingEmptySubsequences: true)
-        guard self.method ~= request.method else {
+        guard self.methods.contains(request.method) else {
             return false
         }
         guard nodes.count >= self.path.count else {
@@ -167,12 +223,39 @@ public extension HTTPRoute {
         }
     }
 
-    private static func components(for target: String) -> (method: String, path: String) {
+    private static func components(for target: String) -> (
+        methods: Set<HTTPMethod>,
+        path: String
+    ) {
         let comps = target.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
         guard comps.count > 1 && !comps[0].hasPrefix("/") else {
-            return (method: "*", path: target)
+            return (methods: HTTPMethod.allMethods, path: target)
         }
-        return (method: String(comps[0]), path: String(comps[1]))
+        
+        let methods = methods(for: comps[0])
+        return (methods: methods, path: String(comps[1]))
+    }
+
+    private static func methods(for target: any StringProtocol) -> Set<HTTPMethod> {
+        // The following formats of the method component are valid:
+        // "" (empty)
+        // "GET" (a single method)
+        // "GET,POST" (comma-delimited list)
+        var methods: Set<HTTPMethod> = target.split(
+            separator: ",",
+            omittingEmptySubsequences: true
+        )
+            .map { HTTPMethod(stringLiteral: String($0)) }
+            .reduce(into: []) { partialResult, method in
+                partialResult.insert(method)
+            }
+
+        // If there are no methods, ensure that we support all methods.
+        if methods.isEmpty {
+            methods.formUnion(HTTPMethod.allMethods)
+        }
+
+        return methods
     }
 
     @available(*, unavailable, message: "renamed: ~= async")

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -142,6 +142,11 @@ public struct HTTPRoute: Sendable {
             item.name == requestItem.name && item.value ~= requestItem.value
         }
     }
+
+    @available(*, deprecated, renamed: "methods", message: "Use ``methods`` instead")
+    public var method: String {
+        fatalError("Use ``methods`` instead.")
+    }
 }
 
 public extension HTTPRoute.Component {

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -87,14 +87,12 @@ public struct HTTPRoute: Sendable {
 
     // MARK: Convenience Initializers
 
-    public init<HTTPMethods: Collection>(
-        methods: HTTPMethods,
+    public init(
+        methods: some Sequence<HTTPMethod>,
         path: String,
         headers: [HTTPHeader: String] = [:],
-        body: (
-            any HTTPBodyPattern
-        )? = nil
-    ) where HTTPMethods.Element == HTTPMethod {
+        body: (any HTTPBodyPattern)? = nil
+    ) {
         self.init(
             methods: Set(methods),
             path: path,

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -32,7 +32,7 @@
 import Foundation
 
 public struct HTTPRoute: Sendable {
-    public var method: Component
+    public var method: HTTPMethod
     public var path: [Component]
     public var query: [QueryItem]
     public var headers: [HTTPHeader: Component]
@@ -48,7 +48,7 @@ public struct HTTPRoute: Sendable {
     }
 
     init(method: String, path: String, headers: [HTTPHeader: String], body: (any HTTPBodyPattern)?) {
-        self.method = Component(method)
+        self.method = HTTPMethod(method)
 
         let comps = HTTPRoute.readComponents(from: path)
         self.path = comps.path
@@ -124,7 +124,7 @@ public extension HTTPRoute {
               patternMatch(body: request.bodySequence) else { return false }
 
         let nodes = request.path.split(separator: "/", omittingEmptySubsequences: true)
-        guard self.method ~= request.method.rawValue else {
+        guard self.method ~= request.method else {
             return false
         }
         guard nodes.count >= self.path.count else {

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -277,6 +277,27 @@ public extension HTTPServer {
     }
 }
 
+public extension HTTPServer {
+
+    func appendRoute(
+        _ path: String,
+        for methods: some Sequence<HTTPMethod>,
+        to handler: some HTTPHandler
+    ) {
+        let route = HTTPRoute(methods: methods, path: path)
+        handlers.appendRoute(route, to: handler)
+    }
+
+    func appendRoute(
+        _ path: String,
+        for methods: some Sequence<HTTPMethod>,
+        handler: @Sendable @escaping (HTTPRequest) async throws -> HTTPResponse
+    ) {
+        let route = HTTPRoute(methods: methods, path: path)
+        handlers.appendRoute(route, handler: handler)
+    }
+}
+
 extension Logging {
 
     func logOpenConnection(_ connection: HTTPConnection) {

--- a/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
@@ -72,6 +72,46 @@ public struct RoutedHTTPHandler: HTTPHandler, Sendable {
     }
 }
 
+public extension RoutedHTTPHandler {
+    mutating func appendRoute(
+        _ path: String,
+        for methods: some Sequence<HTTPMethod>,
+        to handler: some HTTPHandler
+    ) {
+        let route = HTTPRoute(methods: methods, path: path)
+        appendRoute(route, to: handler)
+    }
+
+    mutating func appendRoute(
+        _ path: String,
+        for methods: some Sequence<HTTPMethod>,
+        handler: @Sendable @escaping (HTTPRequest) async throws -> HTTPResponse
+    ) {
+        let route = HTTPRoute(methods: methods, path: path)
+        appendRoute(route, handler: handler)
+    }
+
+    mutating func insertRoute(
+        _ path: String,
+        for methods: some Sequence<HTTPMethod>,
+        at index: Index,
+        to handler: some HTTPHandler
+    ) {
+        let route = HTTPRoute(methods: methods, path: path)
+        insertRoute(route, at: index, to: handler)
+    }
+
+    mutating func insertRoute(
+        _ path: String,
+        for methods: some Sequence<HTTPMethod>,
+        at index: Index,
+        handler: @Sendable @escaping (HTTPRequest) async throws -> HTTPResponse
+    ) {
+        let route = HTTPRoute(methods: methods, path: path)
+        insertRoute(route, at: index, handler: handler)
+    }
+}
+
 extension RoutedHTTPHandler: RangeReplaceableCollection {
     public typealias Index = Array<Element>.Index
     public typealias Element = (route: HTTPRoute, handler: any HTTPHandler)

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -101,9 +101,17 @@ final class HTTPRouteTests: XCTestCase {
             HTTPMethod.allMethods
         )
 
+        XCTAssertTrue(
+            HTTPRoute("GET hello").methods.contains(.GET)
+        )
+
         XCTAssertEqual(
-            HTTPRoute("GET hello").methods,
-            [.GET]
+            HTTPRoute("GET,POST hello").methods,
+            [.GET, .POST]
+        )
+
+        XCTAssertFalse(
+            HTTPRoute("GET,POST hello").methods.contains(.PUT)
         )
     }
 

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -38,7 +38,7 @@ final class HTTPRouteTests: XCTestCase {
         let route = HTTPRoute(method: .PUT, path: "/quick/brown/fox?eats=chips")
 
         XCTAssertEqual(
-            route.method, .PUT
+            route.methods, [.PUT]
         )
         XCTAssertEqual(
             route.path,
@@ -97,13 +97,13 @@ final class HTTPRouteTests: XCTestCase {
 
     func testMethod() {
         XCTAssertEqual(
-            HTTPRoute("hello/world").method,
-            .ANY
+            HTTPRoute("hello/world").methods,
+            HTTPMethod.allMethods
         )
 
         XCTAssertEqual(
-            HTTPRoute("GET hello").method,
-            .GET
+            HTTPRoute("GET hello").methods,
+            [.GET]
         )
     }
 
@@ -160,10 +160,6 @@ final class HTTPRouteTests: XCTestCase {
 
         await AsyncAssertTrue(
             await route ~= HTTPRequest.make(method: .init("GET"), path: "/fish/chips")
-        )
-
-        await AsyncAssertTrue(
-            await route ~= HTTPRequest.make(method: .init("any"), path: "/fish/chips")
         )
 
         await AsyncAssertFalse(

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -38,7 +38,7 @@ final class HTTPRouteTests: XCTestCase {
         let route = HTTPRoute(method: .PUT, path: "/quick/brown/fox?eats=chips")
 
         XCTAssertEqual(
-            route.method, .caseInsensitive("PUT")
+            route.method, .PUT
         )
         XCTAssertEqual(
             route.path,
@@ -98,12 +98,12 @@ final class HTTPRouteTests: XCTestCase {
     func testMethod() {
         XCTAssertEqual(
             HTTPRoute("hello/world").method,
-            .wildcard
+            .ANY
         )
 
         XCTAssertEqual(
             HTTPRoute("GET hello").method,
-            .caseInsensitive("GET")
+            .GET
         )
     }
 
@@ -134,6 +134,14 @@ final class HTTPRouteTests: XCTestCase {
             await route ~= HTTPRequest.make(method: .init(rawValue: "post"), path: "/fish/chips/")
         )
 
+        await AsyncAssertTrue(
+            await route ~= HTTPRequest.make(method: "post", path: "/fish/chips/")
+        )
+
+        await AsyncAssertTrue(
+            await route ~= HTTPRequest.make(method: "POST", path: "/fish/chips/")
+        )
+
         await AsyncAssertFalse(
             await route ~= HTTPRequest.make(method: .GET, path: "/fish/chips")
         )
@@ -151,7 +159,11 @@ final class HTTPRouteTests: XCTestCase {
         )
 
         await AsyncAssertTrue(
-            await route ~= HTTPRequest.make(method: .init("ANY"), path: "/fish/chips")
+            await route ~= HTTPRequest.make(method: .init("GET"), path: "/fish/chips")
+        )
+
+        await AsyncAssertTrue(
+            await route ~= HTTPRequest.make(method: .init("any"), path: "/fish/chips")
         )
 
         await AsyncAssertFalse(

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -85,8 +85,8 @@ private struct MockHandler: HTTPHandler {
 private extension HTTPRoute {
 
     var stringValue: String {
-        let method = method.stringValue
-        let path = path.map(\.stringValue).joined(separator: "/")
+        let method = method.rawValue
+        let path = path.compactMap(\.stringValue).joined(separator: "/")
         return method + " /" + path
     }
 }

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -86,7 +86,7 @@ private extension HTTPRoute {
 
     var stringValue: String {
         let methods = methods.map(\.rawValue).sorted().joined(separator: ",")
-        let path = path.compactMap(\.stringValue).joined(separator: "/")
+        let path = path.map(\.stringValue).joined(separator: "/")
         return methods + " /" + path
     }
 }

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -85,9 +85,9 @@ private struct MockHandler: HTTPHandler {
 private extension HTTPRoute {
 
     var stringValue: String {
-        let method = method.rawValue
+        let methods = methods.map(\.rawValue).sorted().joined(separator: ",")
         let path = path.compactMap(\.stringValue).joined(separator: "/")
-        return method + " /" + path
+        return methods + " /" + path
     }
 }
 


### PR DESCRIPTION
As discussed in #90, this PR proposes to make the `HTTPRoute.method` property of type `Set<HTTPMethod>`.

To do this, I've added a few things:
- `HTTPMethod ` is now `ExpressibleByStringLiteral`.
- `HTTPMethod` now ignores the case of its raw value when checking for equality.

I still need to update the documentation around this, but the tests are passing.