### PR TITLE
AsyncChunkedSequence -> AsyncBufferedSequence

### DIFF
--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -46,7 +46,7 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
         self.storage = .complete(data)
     }
 
-    public init(from bytes: some AsyncChunkedSequence<UInt8>, count: Int) {
+    public init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int) {
         self.storage = .dataSequence(
             AsyncDataSequence(from: bytes, count: count, chunkSize: 4096)
         )
@@ -56,7 +56,7 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
         try self.init(file: url, chunkSize: 4096)
     }
 
-    init(from bytes: some AsyncChunkedSequence<UInt8>, count: Int, chunkSize: Int) {
+    init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int, chunkSize: Int) {
         self.storage = .dataSequence(
             AsyncDataSequence(from: bytes, count: count, chunkSize: chunkSize)
         )

--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -32,6 +32,7 @@
 import Foundation
 import FlyingSocks
 @_spi(Private) import struct FlyingSocks.AsyncDataSequence
+@_spi(Private) import struct FlyingSocks.AsyncBufferedCollection
 
 public struct HTTPBodySequence: Sendable, AsyncSequence {
     public typealias Element = Data
@@ -43,7 +44,7 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
     }
 
     public init(data: Data) {
-        self.storage = .complete(data)
+        self.init(data: data, bufferSize: 4096)
     }
 
     public init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int) {
@@ -60,6 +61,14 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
         self.storage = .dataSequence(
             AsyncDataSequence(from: bytes, count: count, chunkSize: chunkSize)
         )
+    }
+
+    init(data: Data, bufferSize: Int) {
+#if compiler(>=5.9)
+        self.storage = .sequence(.init(data: data, bufferSize: bufferSize))
+#else
+        self.storage = .complete(data)
+#endif
     }
 
     init(file url: URL, maxSizeForComplete: Int = 10_485_760, chunkSize: Int) throws {
@@ -82,6 +91,24 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
     enum Storage: @unchecked Sendable {
         case complete(Data)
         case dataSequence(AsyncDataSequence)
+
+#if compiler(>=5.9)
+        case sequence(Sequence)
+
+        struct Sequence {
+            var sequence: any AsyncBufferedSequence<UInt8>
+            var count: Int
+            var bufferSize: Int
+            var canReplay: Bool
+
+            init(data: Data, bufferSize: Int) {
+                self.sequence = AsyncBufferedCollection(data)
+                self.count = data.count
+                self.bufferSize = bufferSize
+                self.canReplay = true
+            }
+        }
+#endif
     }
 
     public var count: Int {
@@ -90,6 +117,10 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
             return data.count
         case .dataSequence(let sequence):
             return sequence.count
+#if compiler(>=5.9)
+        case .sequence(let sequence):
+            return sequence.count
+#endif
         }
     }
 
@@ -101,12 +132,29 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
             return try await sequence.reduce(into: Data()) {
                 $0.append($1)
             }
+#if compiler(>=5.9)
+        case .sequence(let sequence):
+            return try await sequence.sequence.reduce(into: Data()) {
+                $0.append($1)
+            }
+#endif
         }
     }
 
     func flushIfNeeded() async throws {
         guard case .dataSequence(let sequence) = storage else { return }
         try await sequence.flushIfNeeded()
+    }
+
+    var canReplay: Bool {
+        switch storage {
+        case .complete: return true
+        case .dataSequence: return false
+#if compiler(>=5.9)
+        case .sequence(let sequence):
+            return sequence.canReplay
+#endif
+        }
     }
 }
 
@@ -117,13 +165,21 @@ public extension HTTPBodySequence {
 
         private var storage: Internal
         private var isComplete: Bool = false
+        private var bufferSize: Int = 0
 
         fileprivate init(storage: Storage) {
             switch storage {
             case .complete(let data):
                 self.storage = .complete(data)
+                self.bufferSize = 0
             case .dataSequence(let sequence):
                 self.storage = .dataIterator(sequence.makeAsyncIterator())
+                self.bufferSize = 0
+#if compiler(>=5.9)
+            case .sequence(let sequence):
+                self.storage = .iterator(sequence.sequence.makeAsyncIterator())
+                self.bufferSize = sequence.bufferSize
+#endif
             }
         }
 
@@ -140,12 +196,31 @@ public extension HTTPBodySequence {
                 }
                 storage = .dataIterator(iterator)
                 return result
+#if compiler(>=5.9)
+            case var .iterator(iterator):
+                guard let result = try await getNextBuffer(&iterator) else {
+                    isComplete = true
+                    return nil
+                }
+                storage = .iterator(iterator)
+                return result
+#endif
             }
+        }
+
+        private func getNextBuffer(_ iterator: inout some AsyncBufferedIteratorProtocol<UInt8>) async throws -> Data? {
+            guard let buffer = try await iterator.nextBuffer(atMost: bufferSize) else {
+                return nil
+            }
+            return Data(buffer)
         }
 
         enum Internal: @unchecked Sendable {
             case complete(Data)
             case dataIterator(AsyncDataSequence.AsyncIterator)
+#if compiler(>=5.9)
+            case iterator(any AsyncBufferedIteratorProtocol<UInt8>)
+#endif
         }
     }
 }

--- a/FlyingFox/Sources/HTTPConnection.swift
+++ b/FlyingFox/Sources/HTTPConnection.swift
@@ -92,7 +92,7 @@ extension HTTPConnection: Hashable {
     }
 }
 
-actor HTTPRequestSequence<S: AsyncChunkedSequence & Sendable>: AsyncSequence, AsyncIteratorProtocol, @unchecked Sendable where S.Element == UInt8 {
+actor HTTPRequestSequence<S: AsyncBufferedSequence & Sendable>: AsyncSequence, AsyncIteratorProtocol, @unchecked Sendable where S.Element == UInt8 {
     typealias Element = HTTPRequest
     private let bytes: S
 

--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -34,7 +34,7 @@ import Foundation
 
 struct HTTPDecoder {
 
-    static func decodeRequest(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> HTTPRequest {
+    static func decodeRequest(from bytes: some AsyncBufferedSequence<UInt8>) async throws -> HTTPRequest {
         let status = try await bytes.lines.takeNext()
         let comps = status
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -60,7 +60,7 @@ struct HTTPDecoder {
         )
     }
 
-    static func decodeResponse(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> HTTPResponse {
+    static func decodeResponse(from bytes: some AsyncBufferedSequence<UInt8>) async throws -> HTTPResponse {
         let comps = try await bytes.lines.takeNext()
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
@@ -104,7 +104,7 @@ struct HTTPDecoder {
         return (HTTPHeader(name), value)
     }
 
-    static func readHeaders(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> [HTTPHeader : String] {
+    static func readHeaders(from bytes: some AsyncBufferedSequence<UInt8>) async throws -> [HTTPHeader : String] {
         try await bytes
             .lines
             .prefix { $0 != "\r" && $0 != "" }
@@ -112,7 +112,7 @@ struct HTTPDecoder {
             .reduce(into: [HTTPHeader: String]()) { $0[$1.header] = $1.value }
     }
 
-    static func readBody(from bytes: some AsyncChunkedSequence<UInt8>, length: String?, maxSizeForComplete: Int = 10_485_760) async throws -> HTTPBodySequence {
+    static func readBody(from bytes: some AsyncBufferedSequence<UInt8>, length: String?, maxSizeForComplete: Int = 10_485_760) async throws -> HTTPBodySequence {
         guard let length = length.flatMap(Int.init) else {
             return HTTPBodySequence(data: Data())
         }
@@ -124,12 +124,11 @@ struct HTTPDecoder {
         }
     }
 
-    static func makeBodyData(from bytes: some AsyncChunkedSequence<UInt8>, length: Int) async throws -> Data {
+    static func makeBodyData(from bytes: some AsyncBufferedSequence<UInt8>, length: Int) async throws -> Data {
         var iterator = bytes.makeAsyncIterator()
-        guard let buffer = try await iterator.nextChunk(count: length) else {
-            throw Error("AsyncChunkedSequence prematurely ended")
+        guard let buffer = try await iterator.nextBuffer(count: length) else {
+            throw Error("AsyncBufferedSequence prematurely ended")
         }
-
         return Data(buffer)
     }
 }

--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -118,7 +118,8 @@ struct HTTPDecoder {
         }
 
         if length <= maxSizeForComplete {
-            return try await HTTPBodySequence(data: makeBodyData(from: bytes, length: length))
+            let data = try await makeBodyData(from: bytes, length: length)
+            return HTTPBodySequence(data: data, bufferSize: 4096)
         } else {
             return HTTPBodySequence(from: bytes, count: length, chunkSize: 4096)
         }

--- a/FlyingFox/Sources/WebSocket/AsyncStream+WSFrame.swift
+++ b/FlyingFox/Sources/WebSocket/AsyncStream+WSFrame.swift
@@ -33,7 +33,7 @@ import FlyingSocks
 
 extension AsyncThrowingStream<WSFrame, any Error> {
 
-    static func decodingFrames(from bytes: some AsyncChunkedSequence<UInt8>) -> Self {
+    static func decodingFrames(from bytes: some AsyncBufferedSequence<UInt8>) -> Self {
         AsyncThrowingStream<WSFrame, any Error> {
             do {
                 return try await WSFrameEncoder.decodeFrame(from: bytes)

--- a/FlyingFox/Tests/ConsumingAsyncSequence.swift
+++ b/FlyingFox/Tests/ConsumingAsyncSequence.swift
@@ -31,7 +31,7 @@
 
 import FlyingSocks
 
-final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, AsyncChunkedIteratorProtocol {
+final class ConsumingAsyncSequence<Element>: AsyncBufferedSequence, AsyncBufferedIteratorProtocol {
 
     private var iterator: AnySequence<Element>.Iterator
     private(set) var index: Int = 0
@@ -46,7 +46,7 @@ final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, AsyncChunkedI
         iterator.next()
     }
 
-    func nextChunk(count: Int) async throws -> [Element]? {
+    func nextBuffer(atMost count: Int) async throws -> [Element]? {
         var buffer = [Element]()
         while buffer.count < count,
               let element = iterator.next() {

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -191,8 +191,8 @@ final class HTTPDecoderTests: XCTestCase {
 
     func testBody_ThrowsError_WhenSequenceEnds() async throws {
         await AsyncAssertThrowsError(
-            _ = try await HTTPDecoder.readBody(from: EmptyChunkedSequence(), length: "100"),
-            of: HTTPDecoder.Error.self
+            _ = try await HTTPDecoder.readBody(from: EmptyBufferedSequence(), length: "100"),
+            of: SocketError.self
         )
     }
 
@@ -315,16 +315,16 @@ private extension HTTPDecoder {
     }
 }
 
-private struct EmptyChunkedSequence: AsyncChunkedSequence, AsyncChunkedIteratorProtocol {
+private struct EmptyBufferedSequence: AsyncBufferedSequence, AsyncBufferedIteratorProtocol {
     mutating func next() async throws -> UInt8? {
         return nil
     }
 
-    mutating func nextChunk(count: Int) async throws -> [Element]? {
+    func nextBuffer(atMost count: Int) async throws -> [Element]? {
         return nil
     }
 
-    func makeAsyncIterator() -> EmptyChunkedSequence {
+    func makeAsyncIterator() -> EmptyBufferedSequence {
         self
     }
 

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -196,16 +196,16 @@ final class HTTPDecoderTests: XCTestCase {
         )
     }
 
-    func testBodySequence_IsComplete_WhenSizeIsLessThanMax() async throws {
+    func testBodySequence_CanReplay_WhenSizeIsLessThanMax() async throws {
         let sequence = try await HTTPDecoder.readBodyFromString("Fish & Chips", maxSizeForComplete: 100)
         XCTAssertEqual(sequence.count, 12)
-        XCTAssertTrue(sequence.storage.isComplete)
+        XCTAssertTrue(sequence.canReplay)
     }
 
-    func testBodySequence_IsNotComplete_WhenSizeIsGreaterThanMax() async throws {
+    func testBodySequence_CanNotReplay_WhenSizeIsGreaterThanMax() async throws {
         let sequence = try await HTTPDecoder.readBodyFromString("Fish & Chips", maxSizeForComplete: 2)
         XCTAssertEqual(sequence.count, 12)
-        XCTAssertFalse(sequence.storage.isComplete)
+        XCTAssertFalse(sequence.canReplay)
     }
 
     func testInvalidPathDecodes() {
@@ -329,13 +329,4 @@ private struct EmptyBufferedSequence: AsyncBufferedSequence, AsyncBufferedIterat
     }
 
     typealias Element = UInt8
-}
-
-extension HTTPBodySequence.Storage {
-    var isComplete: Bool {
-        switch self {
-        case .complete: return true
-        case .dataSequence: return false
-        }
-    }
 }

--- a/FlyingSocks/Sources/AsyncBufferedCollection.swift
+++ b/FlyingSocks/Sources/AsyncBufferedCollection.swift
@@ -81,15 +81,3 @@ public extension AsyncBufferedCollection<Data> {
     }
 }
 
-public extension AsyncBufferedCollection {
-
-    func collectChunks(ofLength count: Int) async -> [C.SubSequence] {
-        var collected = [C.SubSequence]()
-        var iterator = makeAsyncIterator()
-
-        while let buffer = await iterator.nextBuffer(atMost: count) {
-            collected.append(buffer)
-        }
-        return collected
-    }
-}

--- a/FlyingSocks/Sources/AsyncBufferedDataSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedDataSequence.swift
@@ -1,0 +1,95 @@
+//
+//  AsyncBufferedDataSequence.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 10/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+@_spi(Private)
+public struct AsyncBufferedCollection<C: Collection>: AsyncBufferedSequence {
+    public typealias Element = C.Element
+
+    private let collection: C
+
+    public init(_ collection: C) {
+        self.collection = collection
+    }
+
+    public func makeAsyncIterator() -> Iterator {
+        Iterator(collection: collection)
+    }
+
+    public struct Iterator: AsyncBufferedIteratorProtocol {
+
+        private let collection: C
+        private var index: C.Index
+
+        init(collection: C) {
+            self.collection = collection
+            self.index = collection.startIndex
+        }
+
+        public mutating func next() async throws -> C.Element? {
+            guard index < collection.endIndex else { return nil }
+            let element = collection[index]
+            index = collection.index(after: index)
+            return element
+        }
+
+        public mutating func nextBuffer(atMost count: Int) async -> C.SubSequence? {
+            guard index < collection.endIndex else { return nil }
+            let endIndex = collection.index(index, offsetBy: count, limitedBy: collection.endIndex) ?? collection.endIndex
+            let buffer = collection[index..<endIndex]
+            index = endIndex
+            return buffer
+        }
+    }
+}
+
+extension AsyncBufferedCollection: Sendable where C: Sendable { }
+
+
+public extension AsyncBufferedCollection<Data> {
+    init(bytes: some Sequence<UInt8>) {
+        self.init(Data(bytes))
+    }
+}
+
+public extension AsyncBufferedCollection {
+
+    func collectChunks(ofLength count: Int) async -> [C.SubSequence] {
+        var collected = [C.SubSequence]()
+        var iterator = makeAsyncIterator()
+
+        while let buffer = await iterator.nextBuffer(atMost: count) {
+            collected.append(buffer)
+        }
+        return collected
+    }
+}

--- a/FlyingSocks/Sources/AsyncBufferedSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedSequence.swift
@@ -1,0 +1,67 @@
+//
+//  AsyncBufferedSequence.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 06/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+/// AsyncSequence that is buffered and can optionally receive contiguous elements in chunks, instead of just one-at-a-time.
+public protocol AsyncBufferedSequence<Element>: AsyncSequence where AsyncIterator: AsyncBufferedIteratorProtocol {
+
+}
+
+public protocol AsyncBufferedIteratorProtocol: AsyncIteratorProtocol {
+    // Buffered elements are returned in this collection type
+    associatedtype Buffer: Collection where Buffer.Element == Element
+
+    /// Retrieves available elements from the buffer. Suspends if 0 elements are available.
+    /// - Parameter count: The maximum number of elements to return
+    /// - Returns: Array with between 1 and the number elements that was requested. Nil is returned if the sequence has ended.
+    mutating func nextBuffer(atMost count: Int) async throws -> Buffer?
+}
+
+public extension AsyncBufferedIteratorProtocol {
+
+    /// Retrieves n elements from sequence in a single array.
+    /// - Parameter count: The maximum number of elements to return
+    /// - Returns: Array with the number of elements that was requested. Nil is returned if the sequence has ended.
+    mutating func nextBuffer(count: Int) async throws -> [Element]? {
+        guard count > 0 else { return [] }
+
+        var buffer = [Element]()
+        while buffer.count < count {
+            try Task.checkCancellation()
+            let remaining = count - buffer.count
+            if let chunk = try await nextBuffer(atMost: remaining) {
+                buffer.append(contentsOf: chunk)
+            } else {
+                throw SocketError.disconnected
+            }
+        }
+        return buffer.isEmpty ? nil : buffer
+    }
+}

--- a/FlyingSocks/Sources/AsyncBufferedSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedSequence.swift
@@ -34,7 +34,7 @@ public protocol AsyncBufferedSequence<Element>: AsyncSequence where AsyncIterato
 
 }
 
-public protocol AsyncBufferedIteratorProtocol: AsyncIteratorProtocol {
+public protocol AsyncBufferedIteratorProtocol<Element>: AsyncIteratorProtocol {
     // Buffered elements are returned in this collection type
     associatedtype Buffer: Collection where Buffer.Element == Element
 

--- a/FlyingSocks/Sources/AsyncChunkedSequence.swift
+++ b/FlyingSocks/Sources/AsyncChunkedSequence.swift
@@ -30,10 +30,12 @@
 //
 
 /// AsyncSequence that is able to also receive elements in chunks, instead of just one-at-a-time.
+@available(*, deprecated, renamed: "AsyncBufferedSequence")
 public protocol AsyncChunkedSequence<Element>: AsyncSequence where AsyncIterator: AsyncChunkedIteratorProtocol {
 
 }
 
+@available(*, deprecated, renamed: "AsyncBufferedIteratorProtocol")
 public protocol AsyncChunkedIteratorProtocol: AsyncIteratorProtocol {
 
     /// Retrieves n elements from sequence in a single array.
@@ -41,12 +43,12 @@ public protocol AsyncChunkedIteratorProtocol: AsyncIteratorProtocol {
     mutating func nextChunk(count: Int) async throws -> [Element]?
 }
 
-@available(*, unavailable, renamed: "AsyncChunkedSequence")
+@available(*, unavailable, renamed: "AsyncBufferedSequence")
 public protocol ChunkedAsyncSequence: AsyncSequence where AsyncIterator: ChunkedAsyncIteratorProtocol {
 
 }
 
-@available(*, unavailable, renamed: "AsyncChunkedIteratorProtocol")
+@available(*, unavailable, renamed: "AsyncBufferedIteratorProtocol")
 public protocol ChunkedAsyncIteratorProtocol: AsyncIteratorProtocol {
     mutating func nextChunk(count: Int) async throws -> [Element]?
 }

--- a/FlyingSocks/Sources/AsyncDataSequence.swift
+++ b/FlyingSocks/Sources/AsyncDataSequence.swift
@@ -38,11 +38,11 @@ public struct AsyncDataSequence: AsyncSequence, Sendable {
 
     private let loader: DataLoader
 
-    public init(from bytes: some AsyncChunkedSequence<UInt8>, count: Int, chunkSize: Int) {
+    public init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int, chunkSize: Int) {
         self.loader = DataLoader(
             count: count,
             chunkSize: chunkSize,
-            iterator: AsyncChunkedSequenceIterator(bytes.makeAsyncIterator())
+            iterator: AsyncBufferedSequenceIterator(bytes.makeAsyncIterator())
         )
     }
 
@@ -166,7 +166,7 @@ private extension AsyncDataSequence {
         }
     }
 
-    final class AsyncChunkedSequenceIterator<I: AsyncChunkedIteratorProtocol>: AsyncDataIterator, @unchecked Sendable where I.Element == UInt8 {
+    final class AsyncBufferedSequenceIterator<I: AsyncBufferedIteratorProtocol>: AsyncDataIterator, @unchecked Sendable where I.Element == UInt8 {
         private var iterator: I
 
         init(_ iterator: I) {
@@ -174,8 +174,8 @@ private extension AsyncDataSequence {
         }
 
         func nextChunk(count: Int) async throws -> Data? {
-            guard let chunk = try await iterator.nextChunk(count: count) else { return nil }
-            return Data(chunk)
+            guard let buffer = try await iterator.nextBuffer(count: count) else { return nil }
+            return Data(buffer)
         }
     }
 

--- a/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
@@ -1,9 +1,9 @@
 //
-//  ConsumingAsyncSequence.swift
+//  AsyncBufferedDataSequenceTests.swift
 //  FlyingFox
 //
-//  Created by Simon Whitty on 17/02/2022.
-//  Copyright © 2022 Simon Whitty. All rights reserved.
+//  Created by Simon Whitty on 10/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
 //
 //  Distributed under the permissive MIT license
 //  Get the latest version from here:
@@ -29,30 +29,42 @@
 //  SOFTWARE.
 //
 
-import FlyingSocks
+@_spi(Private) import struct FlyingSocks.AsyncBufferedCollection
+import Foundation
+import XCTest
 
-final class ConsumingAsyncSequence<Element>: AsyncBufferedSequence, AsyncBufferedIteratorProtocol {
+final class AsyncBufferedDataSequenceTests: XCTestCase {
 
-    private var iterator: AnySequence<Element>.Iterator
-    private(set) var index: Int = 0
+    func testSeqeunce() async {
+        let buffer = AsyncBufferedCollection(bytes: [
+            0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+            0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF
+        ])
 
-    init<T: Sequence>(_ sequence: T) where T.Element == Element {
-        self.iterator = AnySequence(sequence).makeIterator()
+        await AsyncAssertEqual(
+            await buffer.collectChunks(ofLength: 5),
+            [
+                Data([0x0, 0x1, 0x2, 0x3, 0x4]),
+                Data([0x5, 0x6, 0x7, 0x8, 0x9]),
+                Data([0xA, 0xB, 0xC, 0xD, 0xE]),
+                Data([0xF])
+            ]
+        )
     }
 
-    func makeAsyncIterator() -> ConsumingAsyncSequence<Element> { self }
+    func testSequenceCanBeIteratorMultipleTimes() async {
+        let buffer = AsyncBufferedCollection(bytes: [
+            0x0, 0x1, 0x2
+        ])
 
-    func next() async throws -> Element? {
-        iterator.next()
-    }
+        await AsyncAssertEqual(
+            await buffer.collectChunks(ofLength: 5),
+            [Data([0x0, 0x1, 0x2])]
+        )
 
-    func nextBuffer(atMost count: Int) async throws -> [Element]? {
-        var buffer = [Element]()
-        while buffer.count < count,
-              let element = iterator.next() {
-            buffer.append(element)
-        }
-        index += buffer.count
-        return buffer.count > 0 ? buffer : nil
+        await AsyncAssertEqual(
+            await buffer.collectChunks(ofLength: 5),
+            [Data([0x0, 0x1, 0x2])]
+        )
     }
 }

--- a/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
@@ -30,6 +30,7 @@
 //
 
 @_spi(Private) import struct FlyingSocks.AsyncBufferedCollection
+import FlyingSocks
 import Foundation
 import XCTest
 
@@ -42,7 +43,7 @@ final class AsyncBufferedDataSequenceTests: XCTestCase {
         ])
 
         await AsyncAssertEqual(
-            await buffer.collectChunks(ofLength: 5),
+            await buffer.collectBuffers(ofLength: 5),
             [
                 Data([0x0, 0x1, 0x2, 0x3, 0x4]),
                 Data([0x5, 0x6, 0x7, 0x8, 0x9]),
@@ -58,13 +59,26 @@ final class AsyncBufferedDataSequenceTests: XCTestCase {
         ])
 
         await AsyncAssertEqual(
-            await buffer.collectChunks(ofLength: 5),
+            await buffer.collectBuffers(ofLength: 5),
             [Data([0x0, 0x1, 0x2])]
         )
 
         await AsyncAssertEqual(
-            await buffer.collectChunks(ofLength: 5),
+            await buffer.collectBuffers(ofLength: 5),
             [Data([0x0, 0x1, 0x2])]
         )
+    }
+}
+
+private extension AsyncBufferedSequence {
+
+    func collectBuffers(ofLength count: Int) async -> [AsyncIterator.Buffer] {
+        var collected = [AsyncIterator.Buffer]()
+        var iterator = makeAsyncIterator()
+
+        while let buffer = try? await iterator.nextBuffer(atMost: count) {
+            collected.append(buffer)
+        }
+        return collected
     }
 }

--- a/FlyingSocks/Tests/AsyncDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncDataSequenceTests.swift
@@ -268,7 +268,7 @@ extension AsyncDataSequence {
     }
 }
 
-private final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, AsyncChunkedIteratorProtocol {
+private final class ConsumingAsyncSequence<Element>: AsyncBufferedSequence, AsyncBufferedIteratorProtocol {
 
     private var iterator: AnySequence<Element>.Iterator
     private(set) var index: Int = 0
@@ -283,7 +283,7 @@ private final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, Async
         iterator.next()
     }
 
-    func nextChunk(count: Int) async throws -> [Element]? {
+    func nextBuffer(atMost count: Int) async throws -> [Element]? {
         var buffer = [Element]()
         while buffer.count < count,
               let element = iterator.next() {


### PR DESCRIPTION
Deprecates `AsyncChunkedSequence` replacing it with `AsyncBufferedSequence`.

```swift
public protocol AsyncBufferedIteratorProtocol: AsyncIteratorProtocol {
    // Buffered elements are returned in this collection type
    associatedtype Buffer: Collection where Buffer.Element == Element

    /// Retrieves available elements from the buffer. Suspends if 0 elements are available.
    /// - Parameter count: The maximum number of elements to return
    /// - Returns: Array with between 1 and the number elements that was requested. Nil is returned if the sequence has ended.
    mutating func nextBuffer(atMost count: Int) async throws -> Buffer?
}
```