### PR TITLE
HTTPResponse support for Transfer-Encoding: chunked

### DIFF
--- a/FlyingFox/Sources/HTTPChunkedEncodedSequence.swift
+++ b/FlyingFox/Sources/HTTPChunkedEncodedSequence.swift
@@ -1,0 +1,82 @@
+//
+//  HTTPChunkedTransferEncoder.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 09/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import FlyingSocks
+
+struct HTTPChunkedTransferEncoder<Base>: AsyncBufferedSequence, Sendable
+    where Base: AsyncBufferedSequence,
+          Base.Element == UInt8,
+          Base: Sendable {
+    typealias Element = UInt8
+
+    private let bytes: Base
+
+    init(bytes: Base) {
+        self.bytes = bytes
+    }
+
+    func makeAsyncIterator() -> Iterator {
+        Iterator(bytes: bytes.makeAsyncIterator())
+    }
+}
+
+extension HTTPChunkedTransferEncoder {
+
+    struct Iterator: AsyncBufferedIteratorProtocol {
+
+        private var bytes: Base.AsyncIterator
+        private var isComplete: Bool = false
+
+        init(bytes: Base.AsyncIterator) {
+            self.bytes = bytes
+        }
+
+        mutating func next() async throws -> UInt8? {
+            fatalError("call nextBuffer(atMost:)")
+        }
+
+        mutating func nextBuffer(atMost count: Int) async throws -> [UInt8]? {
+            guard !isComplete else { return nil }
+
+            if let buffer = try await bytes.nextBuffer(atMost: count) {
+                var response = Array<UInt8>(String(format:"%02X", buffer.count).utf8)
+                response.append(contentsOf: Array("\r\n".utf8))
+                response.append(contentsOf: buffer)
+                response.append(contentsOf: Array("\r\n".utf8))
+                return response
+            } else {
+                isComplete = true
+                return Array("0\r\n\r\n".utf8)
+            }
+        }
+    }
+}

--- a/FlyingFox/Sources/HTTPHeader.swift
+++ b/FlyingFox/Sources/HTTPHeader.swift
@@ -60,5 +60,6 @@ public extension HTTPHeader {
     static let webSocketAccept  = HTTPHeader("Sec-WebSocket-Accept")
     static let webSocketKey     = HTTPHeader("Sec-WebSocket-Key")
     static let webSocketVersion = HTTPHeader("Sec-WebSocket-Version")
+    static let transferEncoding = HTTPHeader("Transfer-Encoding")
     static let upgrade          = HTTPHeader("Upgrade")
 }

--- a/FlyingFox/Tests/HTTPResponse+Mock.swift
+++ b/FlyingFox/Tests/HTTPResponse+Mock.swift
@@ -29,7 +29,7 @@
 //  SOFTWARE.
 //
 
-import FlyingFox
+@testable import FlyingFox
 import Foundation
 
 extension HTTPResponse {
@@ -43,6 +43,22 @@ extension HTTPResponse {
                      headers: headers,
                      body: body)
     }
+
+#if compiler(>=5.9)
+    static func makeChunked(version: HTTPVersion = .http11,
+                            statusCode: HTTPStatusCode  = .ok,
+                            headers: [HTTPHeader: String] = [:],
+                            body: Data = Data(),
+                            chunkSize: Int = 5) -> Self {
+        let consuming = ConsumingAsyncSequence(body)
+        return HTTPResponse(
+            version: version,
+            statusCode: statusCode,
+            headers: headers,
+            body: HTTPBodySequence(from: consuming, bufferSize: chunkSize)
+        )
+    }
+#endif
 
     static func make(version: HTTPVersion = .http11,
                      statusCode: HTTPStatusCode  = .ok,


### PR DESCRIPTION
Adds support for `HTTPResponse` payloads to be encoded with `Transfer-Encoding: chunked` which removes the need for `Content-Length` being known up front.  

The body must be provided from aa `HTTPBodySequence` from `some AsyncBufferedSequence<UInt8>` without specifying size. The response is then chunked like so:

```
HTTP/1.1 200 OK\r
Transfer-Encoding: chunked\r
\r
0A\r
Hello Worl\r
02\r
d!\r
0\r
\r
```

The client detects end from `0\r\n\r\n`

An example of the above response without chunked encoding is:
```
GET /hello/world HTTP/1.1\r
Content-Length: 5
\r
Hello
```
