### PR TITLE
add SPM support for watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "FlyingFox",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13)
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v8)
     ],
     products: [
         .library(


### PR DESCRIPTION
While we don't run CI and test against watchOS, FlyingFox does work and is useful for SwiftUI previews so we can declare support for it within Package.swift