### PR TITLE
Support multiple values for the same HTTPHeader

### DIFF
--- a/FlyingFox/Sources/HTTPEncoder.swift
+++ b/FlyingFox/Sources/HTTPEncoder.swift
@@ -42,7 +42,7 @@ struct HTTPEncoder {
         if let contentLength = makeContentLength(from: response.payload) {
             httpHeaders[.contentLength] = String(contentLength)
         } else if let encoding = makeTransferEncoding(from: response.payload) {
-            httpHeaders[.transferEncoding] = encoding
+            httpHeaders.addValue(encoding, for: .transferEncoding)
         }
 
         let headers = httpHeaders.map { "\($0.key.rawValue): \($0.value)" }

--- a/FlyingFox/Sources/HTTPHeader.swift
+++ b/FlyingFox/Sources/HTTPHeader.swift
@@ -63,3 +63,21 @@ public extension HTTPHeader {
     static let transferEncoding = HTTPHeader("Transfer-Encoding")
     static let upgrade          = HTTPHeader("Upgrade")
 }
+
+public extension [HTTPHeader: String] {
+
+    func values(for header: HTTPHeader) -> [String] {
+        let value = self[header] ?? ""
+        return value
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map { String($0.trimmingCharacters(in: .whitespaces)) }
+    }
+
+    mutating func setValues(_ values: [String], for header: HTTPHeader) {
+        self[header] = values.joined(separator: ", ")
+    }
+
+    mutating func addValue(_ value: String, for header: HTTPHeader) {
+        setValues(values(for: header) + [value], for: header)
+    }
+}

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -172,6 +172,10 @@ public extension HTTPRoute.Component {
         guard let node = node else { return false }
         return component.patternMatch(to: node)
     }
+
+    static func ~= (component: HTTPRoute.Component, nodes: [String]) -> Bool {
+        nodes.contains { component.patternMatch(to: $0) }
+    }
 }
 
 public extension HTTPRoute {
@@ -218,7 +222,7 @@ public extension HTTPRoute {
 
     private func patternMatch(headers request: [HTTPHeader: String]) -> Bool {
         return headers.allSatisfy { header, value in
-            value ~= request[header]
+            value ~= request.values(for: header)
         }
     }
 

--- a/FlyingFox/Tests/HTTPEncoderTests.swift
+++ b/FlyingFox/Tests/HTTPEncoderTests.swift
@@ -128,7 +128,7 @@ final class HTTPEncoderTests: XCTestCase {
             .makeChunked(
                 version: .http11,
                 statusCode: .ok,
-                headers: [:],
+                headers: [.transferEncoding: "Fish"],
                 body: "Hello World!".data(using: .utf8)!,
                 chunkSize: 10
             )
@@ -138,7 +138,7 @@ final class HTTPEncoderTests: XCTestCase {
             data,
             """
             HTTP/1.1 200 OK\r
-            Transfer-Encoding: chunked\r
+            Transfer-Encoding: Fish, chunked\r
             \r
             0A\r
             Hello Worl\r

--- a/FlyingFox/Tests/HTTPHeaderTests.swift
+++ b/FlyingFox/Tests/HTTPHeaderTests.swift
@@ -1,0 +1,70 @@
+//
+//  HTTPHeaderTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 11/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingFox
+import Foundation
+import XCTest
+
+final class HTTPHeaderTests: XCTestCase {
+
+    func testStringValue() {
+        // given
+        var headers = [HTTPHeader: String]()
+        headers[.transferEncoding] = "Identity"
+
+        XCTAssertEqual(
+            headers[.transferEncoding],
+            "Identity"
+        )
+
+        XCTAssertEqual(
+            headers.values(for: .transferEncoding),
+            ["Identity"]
+        )
+
+        XCTAssertEqual(
+            headers.values(for: .contentType),
+            []
+        )
+    
+        headers.addValue("chunked", for: .transferEncoding)
+
+        XCTAssertEqual(
+            headers[.transferEncoding],
+            "Identity, chunked"
+        )
+
+        XCTAssertEqual(
+            headers.values(for: .transferEncoding),
+            ["Identity", "chunked"]
+        )
+    }
+}

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -339,6 +339,12 @@ final class HTTPRouteTests: XCTestCase {
         await AsyncAssertTrue(
             await route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
+                                      headers: [.contentType: "xml, json"])
+        )
+
+        await AsyncAssertTrue(
+            await route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
                                       headers: [.contentEncoding: "xml",
                                                 .contentType: "json"])
         )


### PR DESCRIPTION
Adds support for multiple, comma delimited values for HTTP headers.

Because `HTTPRequest` and `HTTPResponse` represents all headers as `[HTTPHeader: String]` the support is added by extending this dictionary with additional methods:

```swift
request.headers.addValue("fish", for: .contentType)
request.headers.addValue("chips", for: .contentType)

request.headers[.contentType] == "fish, chips"
```