### PR TITLE
AsyncBufferedSequence suggested size

### DIFF
--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -225,7 +225,7 @@ public extension HTTPBodySequence {
         }
 
         private func getNextBuffer(_ iterator: inout some AsyncBufferedIteratorProtocol<UInt8>) async throws -> Data? {
-            guard let buffer = try await iterator.nextBuffer(atMost: bufferSize) else {
+            guard let buffer = try await iterator.nextBuffer(suggested: bufferSize) else {
                 return nil
             }
             return Data(buffer)

--- a/FlyingFox/Sources/HTTPChunkedEncodedSequence.swift
+++ b/FlyingFox/Sources/HTTPChunkedEncodedSequence.swift
@@ -61,13 +61,13 @@ extension HTTPChunkedTransferEncoder {
         }
 
         mutating func next() async throws -> UInt8? {
-            fatalError("call nextBuffer(atMost:)")
+            fatalError("call nextBuffer(suggested:)")
         }
 
-        mutating func nextBuffer(atMost count: Int) async throws -> [UInt8]? {
+        mutating func nextBuffer(suggested count: Int) async throws -> [UInt8]? {
             guard !isComplete else { return nil }
 
-            if let buffer = try await bytes.nextBuffer(atMost: count) {
+            if let buffer = try await bytes.nextBuffer(suggested: count) {
                 var response = Array<UInt8>(String(format:"%02X", buffer.count).utf8)
                 response.append(contentsOf: Array("\r\n".utf8))
                 response.append(contentsOf: buffer)

--- a/FlyingFox/Tests/ConsumingAsyncSequence.swift
+++ b/FlyingFox/Tests/ConsumingAsyncSequence.swift
@@ -46,7 +46,7 @@ final class ConsumingAsyncSequence<Element>: AsyncBufferedSequence, AsyncBuffere
         iterator.next()
     }
 
-    func nextBuffer(atMost count: Int) async throws -> [Element]? {
+    func nextBuffer(suggested count: Int) async throws -> [Element]? {
         var buffer = [Element]()
         while buffer.count < count,
               let element = iterator.next() {

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -320,7 +320,7 @@ private struct EmptyBufferedSequence: AsyncBufferedSequence, AsyncBufferedIterat
         return nil
     }
 
-    func nextBuffer(atMost count: Int) async throws -> [Element]? {
+    func nextBuffer(suggested count: Int) async throws -> [Element]? {
         return nil
     }
 

--- a/FlyingSocks/Sources/AsyncBufferedCollection.swift
+++ b/FlyingSocks/Sources/AsyncBufferedCollection.swift
@@ -62,7 +62,7 @@ public struct AsyncBufferedCollection<C: Collection>: AsyncBufferedSequence {
             return element
         }
 
-        public mutating func nextBuffer(atMost count: Int) async -> C.SubSequence? {
+        public mutating func nextBuffer(suggested count: Int) async -> C.SubSequence? {
             guard index < collection.endIndex else { return nil }
             let endIndex = collection.index(index, offsetBy: count, limitedBy: collection.endIndex) ?? collection.endIndex
             let buffer = collection[index..<endIndex]

--- a/FlyingSocks/Sources/AsyncBufferedSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedSequence.swift
@@ -39,9 +39,9 @@ public protocol AsyncBufferedIteratorProtocol<Element>: AsyncIteratorProtocol {
     associatedtype Buffer: Collection where Buffer.Element == Element
 
     /// Retrieves available elements from the buffer. Suspends if 0 elements are available.
-    /// - Parameter count: The maximum number of elements to return
+    /// - Parameter count: The suggested number of elements to return
     /// - Returns: Collection with between 1 and the number elements that was requested. Nil is returned if the sequence has ended.
-    mutating func nextBuffer(atMost count: Int) async throws -> Buffer?
+    mutating func nextBuffer(suggested count: Int) async throws -> Buffer?
 }
 
 public extension AsyncBufferedIteratorProtocol {
@@ -56,7 +56,7 @@ public extension AsyncBufferedIteratorProtocol {
         while buffer.count < count {
             try Task.checkCancellation()
             let remaining = count - buffer.count
-            if let chunk = try await nextBuffer(atMost: remaining) {
+            if let chunk = try await nextBuffer(suggested: remaining) {
                 buffer.append(contentsOf: chunk)
             } else {
                 throw SocketError.disconnected

--- a/FlyingSocks/Sources/AsyncSocket.swift
+++ b/FlyingSocks/Sources/AsyncSocket.swift
@@ -204,7 +204,7 @@ public struct AsyncSocketReadSequence: AsyncBufferedSequence, AsyncBufferedItera
         return try await socket.read()
     }
 
-    public func nextBuffer(atMost count: Int) async throws -> [Element]? {
+    public func nextBuffer(suggested count: Int) async throws -> [Element]? {
         try await socket.read(atMost: count)
     }
 }

--- a/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
@@ -76,7 +76,7 @@ private extension AsyncBufferedSequence {
         var collected = [AsyncIterator.Buffer]()
         var iterator = makeAsyncIterator()
 
-        while let buffer = try? await iterator.nextBuffer(atMost: count) {
+        while let buffer = try? await iterator.nextBuffer(suggested: count) {
             collected.append(buffer)
         }
         return collected

--- a/FlyingSocks/Tests/AsyncDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncDataSequenceTests.swift
@@ -283,7 +283,7 @@ private final class ConsumingAsyncSequence<Element>: AsyncBufferedSequence, Asyn
         iterator.next()
     }
 
-    func nextBuffer(atMost count: Int) async throws -> [Element]? {
+    func nextBuffer(suggested count: Int) async throws -> [Element]? {
         var buffer = [Element]()
         while buffer.count < count,
               let element = iterator.next() {


### PR DESCRIPTION
Updates `AsyncBufferedSequence` added in https://github.com/swhitty/FlyingFox/pull/95 to use a "suggested" buffer size, allowing the caller to return more or less than the suggested size

```swift
mutating func nextBuffer(suggested count: Int) async throws -> Buffer?
```