### PR TITLE
Route to Parameter Pack handlers

### DIFF
--- a/FlyingFox/Sources/HTTPRequestParameter.swift
+++ b/FlyingFox/Sources/HTTPRequestParameter.swift
@@ -1,0 +1,87 @@
+//
+//  HTTPRequestParameter.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 11/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+public protocol HTTPRequestParameter {
+    init?(parameter: some StringProtocol)
+}
+
+extension String: HTTPRequestParameter {
+    public init?(parameter: some StringProtocol) {
+        self.init(parameter)
+    }
+}
+
+extension Int: HTTPRequestParameter {
+    public init?(parameter: some StringProtocol) {
+        self.init(parameter)
+    }
+}
+
+#if compiler(>=5.9)
+extension HTTPRequest {
+
+    func extractParameters<each P: HTTPRequestParameter>(
+        for route: HTTPRoute,
+        type: (repeat each P).Type = (repeat each P).self
+    ) throws -> (repeat each P) {
+
+        let indices = route.path.enumerated().compactMap { idx, comp in
+            switch comp {
+            case .parameter:
+                return idx
+            case .wildcard, .caseInsensitive:
+                return nil
+            }
+        }
+
+        var idx = 0
+        return try (repeat getParameter(at: &idx, parameterIndices: indices, type: (each P).self))
+    }
+
+    private func getParameter<P: HTTPRequestParameter>(at index: inout Int, parameterIndices: [Int], type: P.Type) throws -> P {
+        defer { index += 1 }
+
+        guard parameterIndices.indices.contains(index) else {
+            throw CancellationError()
+        }
+
+        let idx = parameterIndices[index]
+        let nodes = path.split(separator: "/", omittingEmptySubsequences: true)
+        guard nodes.indices.contains(idx),
+              let param = P(parameter: nodes[idx]) else {
+            throw CancellationError()
+        }
+        return param
+    }
+}
+#endif

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -68,6 +68,15 @@ public final actor HTTPServer {
         handlers.appendRoute(route, handler: handler)
     }
 
+#if compiler(>=5.9)
+    public func appendRoute<each P: HTTPRequestParameter>(
+        _ route: HTTPRoute,
+        handler: @Sendable @escaping (repeat each P) async throws -> HTTPResponse
+    ) {
+        handlers.appendRoute(route, handler: handler)
+    }
+#endif
+
     public func start() async throws {
         guard state == nil else {
             logger.logCritical("server error: already started")

--- a/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
@@ -44,6 +44,19 @@ public struct RoutedHTTPHandler: HTTPHandler, Sendable {
         append((route, ClosureHTTPHandler(handler)))
     }
 
+#if compiler(>=5.9)
+    public mutating func appendRoute<each P: HTTPRequestParameter>(
+        _ route: HTTPRoute,
+        handler: @Sendable @escaping (repeat each P) async throws -> HTTPResponse
+    ) {
+        let closure = ClosureHTTPHandler { request in
+            let params = try request.extractParameters(for: route, type: (repeat each P).self)
+            return try await handler(repeat each params)
+        }
+        append((route, closure))
+    }
+#endif
+
     public mutating func insertRoute(_ route: HTTPRoute, 
                                      at index: Index,
                                      to handler: some HTTPHandler) {

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -464,4 +464,28 @@ final class HTTPRouteTests: XCTestCase {
         XCTAssertNil(parameters3["bloop"])
         XCTAssertEqual(parameters2["zonk"], 5)
     }
+
+#if compiler(>=5.9)
+    func testPathParameters() {
+        // given
+        let route = HTTPRoute("GET /mock/:id/hello/:zonk")
+        let request = HTTPRequest.make(path: "/mock/12/hello/fish")
+
+        XCTAssertTrue(
+            try request.extractParameters(for: route) == (12, "fish")
+        )
+
+        XCTAssertTrue(
+            try request.extractParameters(for: route) == (12)
+        )
+
+        XCTAssertThrowsError(
+            try request.extractParameters(for: route, type: (Int, Int).self)
+        )
+
+        XCTAssertThrowsError(
+            try request.extractParameters(for: route, type: (Int, String, String).self)
+        )
+    }
+#endif
 }

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -100,6 +100,31 @@ final class RoutedHTTPHandlerTests: XCTestCase {
             "450 chips".data(using: .utf8)
         )
     }
+
+#if compiler(>=5.9)
+    func testParameterPackRoute() async throws {
+        // given
+        var handler = RoutedHTTPHandler()
+
+        handler.appendRoute("GET /:id/hello/:food") { (id: Int, food: String) -> HTTPResponse in
+            HTTPResponse(
+                statusCode: .ok,
+                body: "\(id * 2) \(food)".data(using: .utf8)!
+            )
+        }
+
+        // when then
+        await AsyncAssertEqual(
+            try await handler.handleRequest(.make(path: "/10/hello/fish")).bodyData,
+            "20 fish".data(using: .utf8)
+        )
+
+        await AsyncAssertEqual(
+            try await handler.handleRequest(.make(path: "/450/hello/shrimp")).bodyData,
+            "900 shrimp".data(using: .utf8)
+        )
+    }
+#endif
 }
 
 private struct MockHandler: HTTPHandler {


### PR DESCRIPTION
Swift 5.9+

Extends support for path parameters https://github.com/swhitty/FlyingFox/pull/94 by using parameter packs to route to closures.

Closures must include arguments that conform to `HTTPRequestParameter` (currently only `String` and `Int` conform) and the parameter will be automatically extracted from the path and passed to the closure:

```swift
await server.appendRoute("/fish/:id") { (id: String) in
  HTTPResponse.make(statusCode: .ok, body: "Hello \(id)".data(using: .utf8)!)
}
```

Making a request to `GET /fish/chips` will result in a response body `Hello chips`
