### PR TITLE
Add support for parameters in query string

### DIFF
--- a/FlyingFox/Sources/HTTPRequest+RouteParameter.swift
+++ b/FlyingFox/Sources/HTTPRequest+RouteParameter.swift
@@ -1,0 +1,87 @@
+//
+//  HTTPRequest+RouteParameter.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 13/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+
+import Foundation
+
+public extension HTTPRequest {
+
+    struct RouteParameter: Sendable, Hashable {
+        public var name: String
+        public var value: String
+
+        public init(name: String, value: String) {
+            self.name = name
+            self.value = value
+        }
+    }
+
+    /// Values extracted from the matched route and request
+    var routeParameters: [RouteParameter] { routeParameters() }
+}
+
+extension HTTPRequest {
+
+    func routeParameters(for route: HTTPRoute? = matchedRoute) -> [RouteParameter] {
+        guard let route else { return [] }
+
+        let pathComponents = path
+            .split(separator: "/", omittingEmptySubsequences: true)
+
+        return route.parameters
+            .compactMap {
+                switch $0 {
+                case let .path(name: name, index: index):
+                    if pathComponents.indices.contains(index) {
+                        return RouteParameter(name: name, value: String(pathComponents[index]))
+                    } else {
+                        return nil
+                    }
+                case let .query(name: name, index: index):
+                    if let value = query[index] {
+                        return RouteParameter(name: name, value: value)
+                    } else {
+                        return nil
+                    }
+                }
+            }
+    }
+
+}
+
+public extension Array where Element == HTTPRequest.RouteParameter {
+
+    subscript(_ name: String) -> String? {
+        get {
+            first { $0.name == name }?.value
+        }
+    }
+}

--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -90,29 +90,4 @@ extension HTTPRequest {
     var shouldKeepAlive: Bool {
         headers[.connection]?.caseInsensitiveCompare("keep-alive") == .orderedSame
     }
-
-    public func pathParameter(for identifier: String) -> String? {
-        let components = path
-            .split(separator: "/", omittingEmptySubsequences: true)
-            .map { String($0) }
-
-        guard
-            components.isEmpty == false,
-            let parameterIndex = Self.matchedRoute?.pathParameters[identifier],
-            parameterIndex < components.count
-        else {
-            return nil
-        }
-
-        return components[parameterIndex]
-    }
-
-    public func queryParameter(for identifier: String) -> String? {
-        guard let route = Self.matchedRoute,
-              let queryIdx = route.queryParameters[identifier] else {
-            return nil
-        }
-        let val = query[route.query[queryIdx].name]
-        return val
-    }
 }

--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -106,4 +106,13 @@ extension HTTPRequest {
 
         return components[parameterIndex]
     }
+
+    public func queryParameter(for identifier: String) -> String? {
+        guard let route = Self.matchedRoute,
+              let queryIdx = route.queryParameters[identifier] else {
+            return nil
+        }
+        let val = query[route.query[queryIdx].name]
+        return val
+    }
 }

--- a/FlyingFox/Sources/HTTPRequestParameter.swift
+++ b/FlyingFox/Sources/HTTPRequestParameter.swift
@@ -51,36 +51,22 @@ extension Int: HTTPRequestParameter {
 extension HTTPRequest {
 
     func extractParameters<each P: HTTPRequestParameter>(
-        for route: HTTPRoute,
+        for route: HTTPRoute? = HTTPRequest.matchedRoute,
         type: (repeat each P).Type = (repeat each P).self
     ) throws -> (repeat each P) {
-        let parameters = urlParameters(for: route)
+        let parameters = routeParameters(for: route)
         var idx = 0
         return try (repeat getParameter(at: &idx, parameters: parameters, type: (each P).self))
     }
 
-    private func urlParameters(for route: HTTPRoute) -> [String] {
-        let nodes = path.split(separator: "/", omittingEmptySubsequences: true)
-        var params = [String]()
-        for pathIdx in route.pathParameters.values.sorted() where nodes.indices.contains(pathIdx) {
-            params.append(String(nodes[pathIdx]))
-        }
-        for queryIdx in route.queryParameters.values.sorted() {
-            if let queryValue = query[route.query[queryIdx].name] {
-                params.append(queryValue)
-            }
-        }
-        return params
-    }
-
-    private func getParameter<P: HTTPRequestParameter>(at index: inout Int, parameters: [String], type: P.Type) throws -> P {
+    private func getParameter<P: HTTPRequestParameter>(at index: inout Int, parameters: [RouteParameter], type: P.Type) throws -> P {
         defer { index += 1 }
 
         guard parameters.indices.contains(index) else {
             throw HTTPUnhandledError()
         }
 
-        guard let param = P(parameter: parameters[index]) else {
+        guard let param = P(parameter: parameters[index].value) else {
             throw HTTPUnhandledError()
         }
         return param

--- a/FlyingFox/Sources/HTTPRequestParameter.swift
+++ b/FlyingFox/Sources/HTTPRequestParameter.swift
@@ -65,6 +65,11 @@ extension HTTPRequest {
         for pathIdx in route.pathParameters.values.sorted() where nodes.indices.contains(pathIdx) {
             params.append(String(nodes[pathIdx]))
         }
+        for queryIdx in route.queryParameters.values.sorted() {
+            if let queryValue = query[route.query[queryIdx].name] {
+                params.append(queryValue)
+            }
+        }
         return params
     }
 

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -39,6 +39,7 @@ public struct HTTPRoute: Sendable {
     public var body: (any HTTPBodyPattern)?
 
     public var pathParameters: [String: Int] { path.urlParameters }
+    public var queryParameters: [String: Int] { query.map(\.value).urlParameters }
 
     public init(
         methods: Set<HTTPMethod>,

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -38,8 +38,7 @@ public struct HTTPRoute: Sendable {
     public var headers: [HTTPHeader: Component]
     public var body: (any HTTPBodyPattern)?
 
-    public var pathParameters: [String: Int] { path.urlParameters }
-    public var queryParameters: [String: Int] { query.map(\.value).urlParameters }
+    public var parameters: [Parameter] { pathParameters + queryParameters }
 
     public init(
         methods: Set<HTTPMethod>,
@@ -138,6 +137,19 @@ public struct HTTPRoute: Sendable {
         }
     }
 
+    public enum Parameter: Hashable {
+        case path(name: String, index: Int)
+        case query(name: String, index: String)
+
+        public var name: String {
+            switch self {
+            case .path(name: let name, index: _),
+                 .query(name: let name, index: _):
+                return name
+            }
+        }
+    }
+
     @available(*, deprecated, renamed: "methods", message: "Use ``methods`` instead")
     public var method: Component {
         if methods == HTTPMethod.allMethods {
@@ -188,6 +200,20 @@ public extension HTTPRoute {
 }
 
 private extension HTTPRoute {
+
+    var pathParameters: [Parameter] {
+        path.enumerated().compactMap { (index, component) -> Parameter? in
+            guard let name = component.parameterName else { return nil }
+            return .path(name: name, index: index)
+        }
+    }
+
+    var queryParameters: [Parameter] {
+        query.compactMap { item -> Parameter? in
+            guard let name = item.value.parameterName else { return nil }
+            return .query(name: name, index: item.name)
+        }
+    }
 
     func pathComponent(for index: Int) -> Component? {
         if path.indices.contains(index) {
@@ -333,17 +359,23 @@ extension HTTPRoute.QueryItem: CustomStringConvertible {
     }
 }
 
-private extension [HTTPRoute.Component] {
+private extension HTTPRoute.Component {
 
-    var urlParameters: [String: Int] {
-        enumerated().reduce(into: [:]) { partialResult, item in
-            switch item.element {
-                case let .parameter(name):
-                    partialResult[name] = item.offset
-                case .caseInsensitive,
-                     .wildcard:
-                    break
-            }
+    var parameterName: String? {
+        switch self {
+        case .parameter(let name):
+            return name
+        case .caseInsensitive, .wildcard:
+            return nil
+        }
+    }
+}
+
+public extension Array where Element == HTTPRoute.Parameter {
+
+    subscript(_ name: String) -> HTTPRoute.Parameter? {
+        get {
+            first { $0.name == name }
         }
     }
 }

--- a/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
@@ -50,7 +50,7 @@ public struct RoutedHTTPHandler: HTTPHandler, Sendable {
         handler: @Sendable @escaping (repeat each P) async throws -> HTTPResponse
     ) {
         let closure = ClosureHTTPHandler { request in
-            let params = try request.extractParameters(for: route, type: (repeat each P).self)
+            let params = try request.extractParameters(type: (repeat each P).self)
             return try await handler(repeat each params)
         }
         append((route, closure))

--- a/FlyingFox/Tests/HTTPRequestTests.swift
+++ b/FlyingFox/Tests/HTTPRequestTests.swift
@@ -71,11 +71,7 @@ final class HTTPResponseTests: XCTestCase {
         )
     }
 
-    func testUnknownPathParameter() async {
-        XCTAssertNil(HTTPRequest.make().pathParameter(for: "unknown"))
-    }
-
-    func testUnknownQueryParameter() async {
-        XCTAssertNil(HTTPRequest.make().queryParameter(for: "unknown"))
+    func testUnknownRouteParameter() async {
+        XCTAssertNil(HTTPRequest.make().routeParameters["unknown"])
     }
 }

--- a/FlyingFox/Tests/HTTPRequestTests.swift
+++ b/FlyingFox/Tests/HTTPRequestTests.swift
@@ -74,4 +74,8 @@ final class HTTPResponseTests: XCTestCase {
     func testUnknownPathParameter() async {
         XCTAssertNil(HTTPRequest.make().pathParameter(for: "unknown"))
     }
+
+    func testUnknownQueryParameter() async {
+        XCTAssertNil(HTTPRequest.make().queryParameter(for: "unknown"))
+    }
 }

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -444,25 +444,31 @@ final class HTTPRouteTests: XCTestCase {
         XCTAssertEqual(HTTPRoute("GET,PUT /fish/*").method, .caseInsensitive("GET"))
     }
 
-    func testPathParameters() async {
+    func testRouteParameters() async {
         let route = HTTPRoute("GET /mock/:id")
-        let parameters = route.pathParameters
+        let parameters = route.parameters
         XCTAssertEqual(parameters.count, 1)
-        XCTAssertEqual(parameters["id"], 1) // Position 1 in the components array
+        XCTAssertEqual(parameters["id"], .path(name: "id", index: 1)) // Position 1 in the components array
 
         let route2 = HTTPRoute("GET /mock/:id/:bloop/hello/guys/:zonk")
-        let parameters2 = route2.pathParameters
+        let parameters2 = route2.parameters
         XCTAssertEqual(parameters2.count, 3)
-        XCTAssertEqual(parameters2["id"], 1)
-        XCTAssertEqual(parameters2["bloop"], 2)
-        XCTAssertEqual(parameters2["zonk"], 5)
+        XCTAssertEqual(parameters2["id"], .path(name: "id", index: 1))
+        XCTAssertEqual(parameters2["bloop"], .path(name: "bloop", index: 2))
+        XCTAssertEqual(parameters2["zonk"], .path(name: "zonk", index: 5))
 
         let route3 = HTTPRoute("GET /mock/:id/not:bloop/hello/guys/:zonk")
-        let parameters3 = route3.pathParameters
+        let parameters3 = route3.parameters
         XCTAssertEqual(parameters3.count, 2)
-        XCTAssertEqual(parameters3["id"], 1)
+        XCTAssertEqual(parameters3["id"], .path(name: "id", index: 1))
         XCTAssertNil(parameters3["bloop"])
-        XCTAssertEqual(parameters2["zonk"], 5)
+        XCTAssertEqual(parameters2["zonk"], .path(name: "zonk", index: 5))
+
+        let route4 = HTTPRoute("GET /mock/:id?food=:fish")
+        let parameters4 = route4.parameters
+        XCTAssertEqual(parameters4.count, 2)
+        XCTAssertEqual(parameters4["id"], .path(name: "id", index: 1))
+        XCTAssertEqual(parameters4["fish"], .query(name: "fish", index: "food"))
     }
 
 #if compiler(>=5.9)

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -79,8 +79,12 @@ final class RoutedHTTPHandlerTests: XCTestCase {
         // given
         var handler = RoutedHTTPHandler()
 
-        handler.appendRoute("GET /:id/hello/:food") { request in
-            let body = [request.pathParameter(for: "id"), request.pathParameter(for: "food")]
+        handler.appendRoute("GET /:id/hello?food=:food&qty=:qty") { request in
+            let body = [
+                request.pathParameter(for: "id"),
+                request.queryParameter(for: "food"),
+                request.queryParameter(for: "qty")
+            ]
                 .compactMap { $0 }
                 .joined(separator: " ")
             return HTTPResponse(
@@ -91,13 +95,13 @@ final class RoutedHTTPHandlerTests: XCTestCase {
 
         // when then
         await AsyncAssertEqual(
-            try await handler.handleRequest(.make(path: "/10/hello/fish")).bodyData,
-            "10 fish".data(using: .utf8)
+            try await handler.handleRequest(.make("/10/hello?food=fish&qty=🐟")).bodyString,
+            "10 fish 🐟"
         )
 
         await AsyncAssertEqual(
-            try await handler.handleRequest(.make(path: "/450/hello/chips")).bodyData,
-            "450 chips".data(using: .utf8)
+            try await handler.handleRequest(.make("/450/hello?qty=🍟&food=chips")).bodyString,
+            "450 chips 🍟"
         )
     }
 

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -110,22 +110,22 @@ final class RoutedHTTPHandlerTests: XCTestCase {
         // given
         var handler = RoutedHTTPHandler()
 
-        handler.appendRoute("GET /:id/hello/:food") { (id: Int, food: String) -> HTTPResponse in
+        handler.appendRoute("GET /:id/hello?food=:food&qty=:qty") { (id: Int, food: String, qty: String) -> HTTPResponse in
             HTTPResponse(
                 statusCode: .ok,
-                body: "\(id * 2) \(food)".data(using: .utf8)!
+                body: "\(id * 2) \(food) \(qty)".data(using: .utf8)!
             )
         }
 
         // when then
         await AsyncAssertEqual(
-            try await handler.handleRequest(.make("/10/hello/fish")).bodyString,
-            "20 fish"
+            try await handler.handleRequest(.make("/10/hello?qty=🐟&food=fish")).bodyString,
+            "20 fish 🐟"
         )
 
         await AsyncAssertEqual(
-            try await handler.handleRequest(.make("/450/hello/shrimp")).bodyString,
-            "900 shrimp"
+            try await handler.handleRequest(.make("/450/hello?food=shrimp&qty=🍤")).bodyString,
+            "900 shrimp 🍤"
         )
     }
 #endif

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -81,9 +81,9 @@ final class RoutedHTTPHandlerTests: XCTestCase {
 
         handler.appendRoute("GET /:id/hello?food=:food&qty=:qty") { request in
             let body = [
-                request.pathParameter(for: "id"),
-                request.queryParameter(for: "food"),
-                request.queryParameter(for: "qty")
+                request.routeParameters["id"],
+                request.routeParameters["food"],
+                request.routeParameters["qty"]
             ]
                 .compactMap { $0 }
                 .joined(separator: " ")


### PR DESCRIPTION
Building on https://github.com/swhitty/FlyingFox/pull/94 it is now super easy to also add parameters to query string allowing for:

```swift
 handler.appendRoute("GET /greeting?id=:name") { request in
    let name = request.queryParameter(for: "name")
    return HTTPResponse(statusCode: .ok, body: "Hello \(name)".data(using: .utf8)!)
 }
```

While it may seem redundant it allows us to bind that parameter directly to a parameter pack

```swift
handler.appendRoute("GET /greeting?id=:name") { (name: String) -> HTTPResponse in
   HTTPResponse(statusCode: .ok, body: "Hello \(name)".data(using: .utf8)!)
}
```

Thinking about it more, there may be no need to split the parameters out into path / query sets:

```swift
public func pathParameter(for identifier: String) -> String?  { }
public func queryParameter(for identifier: String) -> String? { }
```

It looks like Vapor calls these [route parameters](https://docs.vapor.codes/basics/routing/#route-parameters) so we could use `routeParameter(for:)` or just `parameter(for:)` like Vapor's [Request.parameters](https://api.vapor.codes/vapor/documentation/vapor/request/parameters)

What do you think @tonyarnold ?