### PR TITLE
Fix Windows build

### DIFF
--- a/FlyingSocks/Sources/SocketPool+Poll.swift
+++ b/FlyingSocks/Sources/SocketPool+Poll.swift
@@ -29,6 +29,9 @@
 //  SOFTWARE.
 //
 
+#if canImport(WinSDK)
+import WinSDK.WinSock2
+#endif
 import Foundation
 
 public extension AsyncSocketPool where Self == SocketPool<Poll> {


### PR DESCRIPTION
Socket+Poll.swift requires the WinSock2 library to be imported for compilation. This allows the poll objects to be recognized by Windows while building.