### PR TITLE
HTTPRequest.Address including X-Forwarded-For

### DIFF
--- a/FlyingFox/Sources/HTTPHeader.swift
+++ b/FlyingFox/Sources/HTTPHeader.swift
@@ -62,6 +62,7 @@ public extension HTTPHeader {
     static let webSocketVersion = HTTPHeader("Sec-WebSocket-Version")
     static let transferEncoding = HTTPHeader("Transfer-Encoding")
     static let upgrade          = HTTPHeader("Upgrade")
+    static let xForwardedFor    = HTTPHeader("X-Forwarded-For")
 }
 
 public extension [HTTPHeader: String] {

--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -38,6 +38,7 @@ public struct HTTPRequest: Sendable {
     public var query: [QueryItem]
     public var headers: [HTTPHeader: String]
     public var bodySequence: HTTPBodySequence
+    public var remoteAddress: Address?
 
     @TaskLocal static var matchedRoute: HTTPRoute?
 
@@ -62,13 +63,15 @@ public struct HTTPRequest: Sendable {
                 path: String,
                 query: [QueryItem],
                 headers: [HTTPHeader: String],
-                body: HTTPBodySequence) {
+                body: HTTPBodySequence,
+                remoteAddress: Address? = nil) {
         self.method = method
         self.version = version
         self.path = path
         self.query = query
         self.headers = headers
         self.bodySequence = body
+        self.remoteAddress = remoteAddress
     }
 
     public init(method: HTTPMethod,
@@ -83,6 +86,7 @@ public struct HTTPRequest: Sendable {
         self.query = query
         self.headers = headers
         self.bodySequence = HTTPBodySequence(data: body)
+        self.remoteAddress = nil
     }
 }
 

--- a/FlyingFox/Tests/HTTPRequest+AddressTests.swift
+++ b/FlyingFox/Tests/HTTPRequest+AddressTests.swift
@@ -1,0 +1,65 @@
+//
+//  HTTPRequest+AddressTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 03/08/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import FlyingFox
+import XCTest
+
+final class HTTPRequestAddressTests: XCTestCase {
+
+    typealias Address = HTTPRequest.Address
+
+    func testRemoteAddress_IP4() {
+        let request = HTTPRequest.make(remoteAddress: .ip4("fish", port: 80))
+        XCTAssertEqual(request.remoteAddress, .ip4("fish", port: 80))
+        XCTAssertEqual(request.remoteIPAddress, "fish")
+    }
+
+    func testRemoteAddress_IP6() {
+        let request = HTTPRequest.make(remoteAddress: .ip6("chips", port: 8080))
+        XCTAssertEqual(request.remoteAddress, .ip6("chips", port: 8080))
+        XCTAssertEqual(request.remoteIPAddress, "chips")
+    }
+
+    func testRemoteAddress_Unix() {
+        let request = HTTPRequest.make(remoteAddress: .unix("shrimp"))
+        XCTAssertEqual(request.remoteAddress, .unix("shrimp"))
+        XCTAssertNil(request.remoteIPAddress)
+    }
+
+    func testRemoteAddress_XForwardedFor() {
+        let request = HTTPRequest.make(
+            headers: [.xForwardedFor: "fish, chips"],
+            remoteAddress: .ip4("shrimp", port: 80)
+        )
+        XCTAssertEqual(request.remoteAddress, .ip4("shrimp", port: 80))
+        XCTAssertEqual(request.remoteIPAddress, "fish")
+    }
+}


### PR DESCRIPTION
Adds `HTTPRequest.remoteAddress` allowing handlers to receive the address and port of the remove client making the request.

`HTTPRequest.remoteIPAddress` is also added as a convenience, preferring the client value from the `X-Forwarded-For` header which is useful for handlers running behind a reverse proxy.