### PR TITLE
package access control

### DIFF
--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -31,8 +31,6 @@
 
 import Foundation
 import FlyingSocks
-@_spi(Private) import struct FlyingSocks.AsyncDataSequence
-@_spi(Private) import struct FlyingSocks.AsyncBufferedCollection
 
 public struct HTTPBodySequence: Sendable, AsyncSequence {
     public typealias Element = Data

--- a/FlyingFox/Sources/HTTPClient.swift
+++ b/FlyingFox/Sources/HTTPClient.swift
@@ -34,6 +34,8 @@ import FlyingSocks
 @_spi(Private)
 public struct _HTTPClient {
 
+    public init() { }
+
     public func sendHTTPRequest(_ request: HTTPRequest, to address: some SocketAddress) async throws -> HTTPResponse {
         let socket = try await AsyncSocket.connected(to: address)
         try await socket.writeRequest(request)
@@ -45,8 +47,7 @@ public struct _HTTPClient {
     }
 }
 
-@_spi(Private)
-public extension AsyncSocket {
+package extension AsyncSocket {
     func writeRequest(_ request: HTTPRequest) async throws {
         try await write(HTTPEncoder.encodeRequest(request))
     }

--- a/FlyingFox/Sources/HTTPConnection.swift
+++ b/FlyingFox/Sources/HTTPConnection.swift
@@ -30,7 +30,6 @@
 //
 
 import FlyingSocks
-@_spi(Private) import func FlyingSocks.withThrowingTimeout
 import Foundation
 
 struct HTTPConnection: Sendable {

--- a/FlyingFox/Sources/HTTPServer+Listening.swift
+++ b/FlyingFox/Sources/HTTPServer+Listening.swift
@@ -31,8 +31,6 @@
 
 import Foundation
 import FlyingSocks
-@_spi(Private) import func FlyingSocks.withThrowingTimeout
-@_spi(Private) import func FlyingSocks.withIdentifiableThrowingContinuation
 
 extension HTTPServer {
 

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -30,7 +30,6 @@
 //
 
 import FlyingSocks
-@_spi(Private) import func FlyingSocks.withThrowingTimeout
 import Foundation
 #if canImport(WinSDK)
 import WinSDK.WinSock2

--- a/FlyingFox/Sources/URLSession+Async.swift
+++ b/FlyingFox/Sources/URLSession+Async.swift
@@ -30,7 +30,7 @@
 //
 
 import Foundation
-@_spi(Private) import struct FlyingSocks.AllocatedLock
+import FlyingSocks
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/FlyingFox/Tests/HTTPBodySequenceTests.swift
+++ b/FlyingFox/Tests/HTTPBodySequenceTests.swift
@@ -30,7 +30,7 @@
 //
 
 @testable import FlyingFox
-@_spi(Private) import struct FlyingSocks.AsyncDataSequence
+import struct FlyingSocks.AsyncDataSequence
 import XCTest
 
 final class HTTPBodySequenceTests: XCTestCase {

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -29,7 +29,7 @@
 //  SOFTWARE.
 //
 
-@_spi(Private) @testable import FlyingFox
+@testable import FlyingFox
 @testable import FlyingSocks
 import XCTest
 import Foundation

--- a/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
@@ -29,7 +29,7 @@
 //  SOFTWARE.
 //
 
-@_spi(Private) @testable import FlyingFox
+@testable import FlyingFox
 @testable import FlyingSocks
 import Foundation
 import XCTest

--- a/FlyingSocks/Sources/AllocatedLock.swift
+++ b/FlyingSocks/Sources/AllocatedLock.swift
@@ -31,26 +31,24 @@
 
 // Backports the Swift interface around os_unfair_lock_t available in recent Darwin platforms
 //
-@_spi(Private)
-public struct AllocatedLock<State>: @unchecked Sendable {
+package struct AllocatedLock<State>: @unchecked Sendable {
 
     @usableFromInline
     let storage: Storage
 
-    public init(initialState: State) {
+    package init(initialState: State) {
         self.storage = Storage(initialState: initialState)
     }
 
     @inlinable
-    public func withLock<R>(_ body: @Sendable (inout State) throws -> R) rethrows -> R where R: Sendable {
+    package func withLock<R>(_ body: @Sendable (inout State) throws -> R) rethrows -> R where R: Sendable {
         storage.lock()
         defer { storage.unlock() }
         return try body(&storage.state)
     }
 }
 
-@_spi(Private)
-public extension AllocatedLock where State == Void {
+package extension AllocatedLock where State == Void {
 
     init() {
         self.storage = Storage(initialState: ())

--- a/FlyingSocks/Sources/AsyncBufferedCollection.swift
+++ b/FlyingSocks/Sources/AsyncBufferedCollection.swift
@@ -31,21 +31,20 @@
 
 import Foundation
 
-@_spi(Private)
-public struct AsyncBufferedCollection<C: Collection>: AsyncBufferedSequence {
-    public typealias Element = C.Element
+package struct AsyncBufferedCollection<C: Collection>: AsyncBufferedSequence {
+    package typealias Element = C.Element
 
     private let collection: C
 
-    public init(_ collection: C) {
+    package init(_ collection: C) {
         self.collection = collection
     }
 
-    public func makeAsyncIterator() -> Iterator {
+    package func makeAsyncIterator() -> Iterator {
         Iterator(collection: collection)
     }
 
-    public struct Iterator: AsyncBufferedIteratorProtocol {
+    package struct Iterator: AsyncBufferedIteratorProtocol {
 
         private let collection: C
         private var index: C.Index
@@ -55,14 +54,14 @@ public struct AsyncBufferedCollection<C: Collection>: AsyncBufferedSequence {
             self.index = collection.startIndex
         }
 
-        public mutating func next() async throws -> C.Element? {
+        package mutating func next() async throws -> C.Element? {
             guard index < collection.endIndex else { return nil }
             let element = collection[index]
             index = collection.index(after: index)
             return element
         }
 
-        public mutating func nextBuffer(suggested count: Int) async -> C.SubSequence? {
+        package mutating func nextBuffer(suggested count: Int) async -> C.SubSequence? {
             guard index < collection.endIndex else { return nil }
             let endIndex = collection.index(index, offsetBy: count, limitedBy: collection.endIndex) ?? collection.endIndex
             let buffer = collection[index..<endIndex]
@@ -75,7 +74,7 @@ public struct AsyncBufferedCollection<C: Collection>: AsyncBufferedSequence {
 extension AsyncBufferedCollection: Sendable where C: Sendable { }
 
 
-public extension AsyncBufferedCollection<Data> {
+package extension AsyncBufferedCollection<Data> {
     init(bytes: some Sequence<UInt8>) {
         self.init(Data(bytes))
     }

--- a/FlyingSocks/Sources/AsyncDataSequence.swift
+++ b/FlyingSocks/Sources/AsyncDataSequence.swift
@@ -31,14 +31,13 @@
 
 import Foundation
 
-@_spi(Private)
 /// AsyncSequence that can only be iterated one-time-only. Suitable for large data sizes.
-public struct AsyncDataSequence: AsyncSequence, Sendable {
-    public typealias Element = Data
+package struct AsyncDataSequence: AsyncSequence, Sendable {
+    package typealias Element = Data
 
     private let loader: DataLoader
 
-    public init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int, chunkSize: Int) {
+    package init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int, chunkSize: Int) {
         self.loader = DataLoader(
             count: count,
             chunkSize: chunkSize,
@@ -46,7 +45,7 @@ public struct AsyncDataSequence: AsyncSequence, Sendable {
         )
     }
 
-    public init(file handle: FileHandle, count: Int, chunkSize: Int) {
+    package init(file handle: FileHandle, count: Int, chunkSize: Int) {
         self.loader = DataLoader(
             count: count,
             chunkSize: chunkSize,
@@ -54,14 +53,14 @@ public struct AsyncDataSequence: AsyncSequence, Sendable {
         )
     }
 
-    public var count: Int { loader.count }
+    package var count: Int { loader.count }
 
-    public func makeAsyncIterator() -> Iterator {
+    package func makeAsyncIterator() -> Iterator {
         Iterator(loader: loader)
     }
 
-    public struct Iterator: AsyncIteratorProtocol {
-        public typealias Element = Data
+    package struct Iterator: AsyncIteratorProtocol {
+        package typealias Element = Data
 
         private let loader: DataLoader
 
@@ -71,7 +70,7 @@ public struct AsyncDataSequence: AsyncSequence, Sendable {
             self.loader = loader
         }
 
-        public mutating func next() async throws -> Data? {
+        package mutating func next() async throws -> Data? {
             let data = try await loader.nextData(from: index)
             if let data = data {
                 index += data.count
@@ -80,12 +79,12 @@ public struct AsyncDataSequence: AsyncSequence, Sendable {
         }
     }
 
-    public func flushIfNeeded() async throws {
+    package func flushIfNeeded() async throws {
         try await loader.flushIfNeeded()
     }
 }
 
-public extension AsyncDataSequence {
+package extension AsyncDataSequence {
 
     static func size(of file: URL) throws -> Int {
         let att = try FileManager.default.attributesOfItem(atPath: file.path)
@@ -96,7 +95,7 @@ public extension AsyncDataSequence {
     }
 
     struct FileSizeError: LocalizedError {
-        public var errorDescription: String? = "File size not found"
+        package var errorDescription: String? = "File size not found"
     }
 }
 
@@ -147,7 +146,7 @@ private extension AsyncDataSequence {
             return Data(buffer)
         }
 
-        public func flushIfNeeded() async throws {
+        package func flushIfNeeded() async throws {
             switch state {
             case .ready(index: var index):
                 while let data = try await nextData(from: index) {

--- a/FlyingSocks/Sources/IdentifiableContinuation.swift
+++ b/FlyingSocks/Sources/IdentifiableContinuation.swift
@@ -45,8 +45,7 @@
 ///   - handler: Cancellation closure executed when the current Task is cancelled.  Handler is always called _after_ the body closure is compeled.
 /// - Returns: The value continuation is resumed with.
 @_unsafeInheritExecutor
-@_spi(Private)
-public func withIdentifiableContinuation<T>(
+package func withIdentifiableContinuation<T>(
   isolation: isolated some Actor,
   function: String = #function,
   body: (IdentifiableContinuation<T, Never>) -> Void,
@@ -94,8 +93,7 @@ public func withIdentifiableContinuation<T>(
 ///   - handler: Cancellation closure executed when the current Task is cancelled.  Handler is always called _after_ the body closure is compeled.
 /// - Returns: The value continuation is resumed with.
 @_unsafeInheritExecutor
-@_spi(Private)
-public func withIdentifiableThrowingContinuation<T>(
+package func withIdentifiableThrowingContinuation<T>(
   isolation: isolated some Actor,
   function: String = #function,
   body: (IdentifiableContinuation<T, any Error>) -> Void,
@@ -127,20 +125,19 @@ public func withIdentifiableThrowingContinuation<T>(
     }
 }
 
-@_spi(Private)
-public struct IdentifiableContinuation<T, E>: Sendable, Identifiable where E: Error {
+package struct IdentifiableContinuation<T, E>: Sendable, Identifiable where E: Error {
 
-    public let id: ID
+    package let id: ID
 
-    public final class ID: Hashable, Sendable {
+    package final class ID: Hashable, Sendable {
 
         init() { }
 
-        public func hash(into hasher: inout Hasher) {
+        package func hash(into hasher: inout Hasher) {
             ObjectIdentifier(self).hash(into: &hasher)
         }
 
-        public static func == (lhs: IdentifiableContinuation<T, E>.ID, rhs: IdentifiableContinuation<T, E>.ID) -> Bool {
+        package static func == (lhs: IdentifiableContinuation<T, E>.ID, rhs: IdentifiableContinuation<T, E>.ID) -> Bool {
             lhs === rhs
         }
     }
@@ -152,19 +149,19 @@ public struct IdentifiableContinuation<T, E>: Sendable, Identifiable where E: Er
 
     private let continuation: CheckedContinuation<T, E>
 
-    public func resume(returning value: T) {
+    package func resume(returning value: T) {
         continuation.resume(returning: value)
     }
 
-    public func resume(throwing error: E) {
+    package func resume(throwing error: E) {
         continuation.resume(throwing: error)
     }
 
-    public func resume(with result: Result<T, E>) {
+    package func resume(with result: Result<T, E>) {
         continuation.resume(with: result)
     }
 
-    public func resume() where T == () {
+    package func resume() where T == () {
         continuation.resume()
     }
 }

--- a/FlyingSocks/Sources/Task+Timeout.swift
+++ b/FlyingSocks/Sources/Task+Timeout.swift
@@ -31,8 +31,7 @@
 
 import Foundation
 
-@_spi(Private)
-public func withThrowingTimeout<T: Sendable>(seconds: TimeInterval, body: @escaping @Sendable () async throws -> T) async throws -> T {
+package func withThrowingTimeout<T: Sendable>(seconds: TimeInterval, body: @escaping @Sendable () async throws -> T) async throws -> T {
     try await withThrowingTaskGroup(of: T.self) { group -> T in
         group.addTask {
             try await body()
@@ -47,13 +46,11 @@ public func withThrowingTimeout<T: Sendable>(seconds: TimeInterval, body: @escap
     }
 }
 
-@_spi(Private)
-public struct TimeoutError: LocalizedError {
-    public var errorDescription: String? = "Timed out before completion"
+package struct TimeoutError: LocalizedError {
+    package var errorDescription: String? = "Timed out before completion"
 }
 
-@_spi(Private)
-public extension Task {
+package extension Task {
 
     enum CancellationPolicy: Sendable {
         /// Cancels the task when the task retrieving the value is cancelled

--- a/FlyingSocks/Tests/AllocatedLockTests.swift
+++ b/FlyingSocks/Tests/AllocatedLockTests.swift
@@ -29,7 +29,7 @@
 //  SOFTWARE.
 //
 
-@_spi(Private) import struct FlyingSocks.AllocatedLock
+import FlyingSocks
 import XCTest
 
 final class AllocatedLockTests: XCTestCase {

--- a/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
@@ -29,7 +29,6 @@
 //  SOFTWARE.
 //
 
-@_spi(Private) import struct FlyingSocks.AsyncBufferedCollection
 import FlyingSocks
 import Foundation
 import XCTest

--- a/FlyingSocks/Tests/AsyncDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncDataSequenceTests.swift
@@ -30,7 +30,6 @@
 //
 
 import FlyingSocks
-@_spi(Private) import struct FlyingSocks.AsyncDataSequence
 import XCTest
 
 final class AsyncDataSequenceTests: XCTestCase {

--- a/FlyingSocks/Tests/IdentifiableContinuationTests.swift
+++ b/FlyingSocks/Tests/IdentifiableContinuationTests.swift
@@ -29,9 +29,7 @@
 //  SOFTWARE.
 //
 
-@_spi(Private) import struct FlyingSocks.IdentifiableContinuation
-@_spi(Private) import func FlyingSocks.withIdentifiableContinuation
-@_spi(Private) import func FlyingSocks.withIdentifiableThrowingContinuation
+import FlyingSocks
 import XCTest
 
 final class IdentifiableContinuationAsyncTests: XCTestCase {

--- a/FlyingSocks/Tests/SocketPoolTests.swift
+++ b/FlyingSocks/Tests/SocketPoolTests.swift
@@ -30,8 +30,6 @@
 //
 
 @testable import FlyingSocks
-@_spi(Private) import struct FlyingSocks.IdentifiableContinuation
-@_spi(Private) import func FlyingSocks.withIdentifiableThrowingContinuation
 import XCTest
 
 final class SocketPoolTests: XCTestCase {

--- a/FlyingSocks/Tests/Task+TimeoutTests.swift
+++ b/FlyingSocks/Tests/Task+TimeoutTests.swift
@@ -144,8 +144,6 @@ final class TaskTimeoutTests: XCTestCase {
     }
 }
 
-@_spi(Private) import func FlyingSocks.withThrowingTimeout
-
 extension Task where Success: Sendable, Failure == any Error {
 
     // Start a new Task with a timeout.


### PR DESCRIPTION
Now that Swift 5.9 is the minimum supported language version we can replace all `spi(private)` with `package` from [SE-0386](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0386-package-access-modifier.md)

