### PR TITLE
Fix: Dynamic Stack Buffer Overflow

### DIFF
--- a/FlyingSocks/Sources/SocketAddress.swift
+++ b/FlyingSocks/Sources/SocketAddress.swift
@@ -116,12 +116,20 @@ public extension SocketAddress {
     }
 
     func makeStorage() -> sockaddr_storage {
+        var storage = sockaddr_storage()
         var addr = self
-        return withUnsafePointer(to: &addr) {
-            $0.withMemoryRebound(to: sockaddr_storage.self, capacity: 1) {
-                $0.pointee
+        let addrSize = MemoryLayout<Self>.size
+        let storageSize = MemoryLayout<sockaddr_storage>.size
+
+        withUnsafePointer(to: &addr) { addrPtr in
+            let addrRawPtr = UnsafeRawPointer(addrPtr)
+            withUnsafeMutablePointer(to: &storage) { storagePtr in
+                let storageRawPtr = UnsafeMutableRawPointer(storagePtr)
+                let copySize = min(addrSize, storageSize)
+                storageRawPtr.copyMemory(from: addrRawPtr, byteCount: copySize)
             }
         }
+        return storage
     }
 }
 


### PR DESCRIPTION
**Given**
FlyingFox: 0.14.0
Device: iPhone 15 iOS 17.5 (Simulator)

**When**
Turn on **AddressSanitizer** in **Xcode**.

**Then**
I've encountered a dynamic stack buffer overflow error.

```assembly
Address 0x00016cead4bc is located in stack of thread T0
SUMMARY: AddressSanitizer: dynamic-stack-buffer-overflow (/Users/__WHOAMI__/Library/Developer/CoreSimulator/Devices/95E3F30B-6F79-410F-8A4C-68EC8706820E/data/Containers/Bundle/Application/560390B8-52F3-4465-9BD6-82AA4A9EB557/__APP__.app/__APP__:arm64+0x103471ea4) in closure #1 (Swift.UnsafePointer<__C.sockaddr_storage>) -> __C.sockaddr_storage in closure #1 (Swift.UnsafePointer<A>) -> __C.sockaddr_storage in (extension in FlyingSocks):FlyingSocks.SocketAddress.makeStorage() -> __C.sockaddr_storage+0x9b0
Shadow bytes around the buggy address:
  0x00016cead200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016cead280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016cead300: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016cead380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016cead400: 00 00 00 00 ca ca ca ca 00 00 00 00 cb cb cb cb
=>0x00016cead480: ca ca ca ca 00 00 00[04]cb cb cb cb 00 00 00 00
  0x00016cead500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016cead580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016cead600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016cead680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016cead700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==30279==ABORTING
```

**Source of error:**
https://github.com/swhitty/FlyingFox/blob/3d58c544fed69742fe41248863d1b89d9342097b/FlyingSocks/Sources/SocketAddress.swift#L118-L126

This is probably due to the program writes more data to a buffer located on the stack than it was allocated for, leading to memory corruption.

The `makeStorage()` function is attempting to cast a socket address (`sockaddr_in`, `sockaddr_in6`, or `sockaddr_un`) to a `sockaddr_storage` object. The issue arises when the memory layout of `sockaddr_storage` does not align with the original structure's layout, causing an overflow.