### PR TITLE
move makeStorage() to tests

### DIFF
--- a/FlyingFox/Sources/HTTPServer+Configuration.swift
+++ b/FlyingFox/Sources/HTTPServer+Configuration.swift
@@ -1,0 +1,55 @@
+//
+//  HTTPServer+Configuration.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 06/08/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import FlyingSocks
+
+public extension HTTPServer {
+
+    struct Configuration: Sendable {
+        public var address: any SocketAddress
+        public var timeout: TimeInterval
+        public var pool: any AsyncSocketPool
+        public var logger: any Logging
+
+
+
+        public init(address: some SocketAddress,
+                    timeout: TimeInterval = 15,
+                    pool: any AsyncSocketPool = HTTPServer.defaultPool(),
+                    logger: any Logging = HTTPServer.defaultLogger()) {
+            self.address = address
+            self.timeout = timeout
+            self.pool = pool
+            self.logger = logger
+        }
+    }
+}

--- a/FlyingSocks/Sources/AsyncSocket.swift
+++ b/FlyingSocks/Sources/AsyncSocket.swift
@@ -83,7 +83,7 @@ public struct AsyncSocket: Sendable {
                                  pool: some AsyncSocketPool,
                                  timeout: TimeInterval = 5) async throws -> Self {
         try await withThrowingTimeout(seconds: timeout) {
-            let socket = try Socket(domain: Int32(address.makeStorage().ss_family), type: Socket.stream)
+            let socket = try Socket(domain: Int32(type(of: address).family), type: Socket.stream)
             let asyncSocket = try AsyncSocket(socket: socket, pool: pool)
             try await asyncSocket.connect(to: address)
             return asyncSocket

--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -109,19 +109,6 @@ public struct Socket: Sendable, Hashable {
         }
     }
 
-    public func bind(to storage: sockaddr_storage) throws {
-        switch Int32(storage.ss_family) {
-        case AF_INET:
-            try bind(to: sockaddr_in.make(from: storage))
-        case AF_INET6:
-            try bind(to: sockaddr_in6.make(from: storage))
-        case AF_UNIX:
-            try bind(to: sockaddr_un.make(from: storage))
-        default:
-            throw SocketError.unsupportedAddress
-        }
-    }
-
     public func listen(maxPendingConnection: Int32 = SOMAXCONN) throws {
         if Socket.listen(file.rawValue, maxPendingConnection) == -1 {
             let error = SocketError.makeFailed("Listen")

--- a/FlyingSocks/Sources/SocketAddress.swift
+++ b/FlyingSocks/Sources/SocketAddress.swift
@@ -114,23 +114,6 @@ public extension SocketAddress {
             }
         }
     }
-
-    func makeStorage() -> sockaddr_storage {
-        var storage = sockaddr_storage()
-        var addr = self
-        let addrSize = MemoryLayout<Self>.size
-        let storageSize = MemoryLayout<sockaddr_storage>.size
-
-        withUnsafePointer(to: &addr) { addrPtr in
-            let addrRawPtr = UnsafeRawPointer(addrPtr)
-            withUnsafeMutablePointer(to: &storage) { storagePtr in
-                let storageRawPtr = UnsafeMutableRawPointer(storagePtr)
-                let copySize = min(addrSize, storageSize)
-                storageRawPtr.copyMemory(from: addrRawPtr, byteCount: copySize)
-            }
-        }
-        return storage
-    }
 }
 
 extension Socket {

--- a/FlyingSocks/Tests/SocketAddressTests.swift
+++ b/FlyingSocks/Tests/SocketAddressTests.swift
@@ -298,3 +298,24 @@ final class SocketAddressTests: XCTestCase {
         }
     }
 }
+
+
+private extension SocketAddress {
+
+    func makeStorage() -> sockaddr_storage {
+        var storage = sockaddr_storage()
+        var addr = self
+        let addrSize = MemoryLayout<Self>.size
+        let storageSize = MemoryLayout<sockaddr_storage>.size
+
+        withUnsafePointer(to: &addr) { addrPtr in
+            let addrRawPtr = UnsafeRawPointer(addrPtr)
+            withUnsafeMutablePointer(to: &storage) { storagePtr in
+                let storageRawPtr = UnsafeMutableRawPointer(storagePtr)
+                let copySize = min(addrSize, storageSize)
+                storageRawPtr.copyMemory(from: addrRawPtr, byteCount: copySize)
+            }
+        }
+        return storage
+    }
+}

--- a/FlyingSocks/Tests/SocketTests.swift
+++ b/FlyingSocks/Tests/SocketTests.swift
@@ -175,7 +175,7 @@ final class SocketTests: XCTestCase {
     func testSocketBind_ToINET() throws {
         let socket = try Socket(domain: AF_INET, type: Socket.stream)
         try socket.setValue(true, for: .localAddressReuse)
-        let address = Socket.makeAddressINET(port:5050).makeStorage()
+        let address = Socket.makeAddressINET(port:5050)
         XCTAssertNoThrow(
             try socket.bind(to: address)
         )
@@ -191,21 +191,9 @@ final class SocketTests: XCTestCase {
         )
     }
 
-    func testSocketBind_ToInvalidStorage_ThrowsUnsupported() {
-        let socket = Socket(file: -1)
-        var addr = Socket.makeAddressUnix(path: "/var/fox/xyz").makeStorage()
-        addr.ss_family = sa_family_t(AF_IPX)
-        XCTAssertThrowsError(
-            try socket.bind(to: addr),
-            of: SocketError.self
-        ) {
-            XCTAssertEqual($0, .unsupportedAddress)
-        }
-    }
-
     func testSocketBind_ToStorage_ThrowsError_WhenInvalid() {
         let socket = Socket(file: -1)
-        let address = Socket.makeAddressINET6(port: 8080).makeStorage()
+        let address = Socket.makeAddressINET6(port: 8080)
         XCTAssertThrowsError(
             try socket.bind(to: address)
         )


### PR DESCRIPTION
`sockaddr_storage` is only really used as box for any address, but since [SE-0352](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0352-implicit-open-existentials.md) we can now just use `any SocketAddress` and let the compiler box / unbox from an existential.

`HTTPServer.Configuration` is now added to encapsulate the growing number of properties used to start `HTTPServer`.

The recently fixed `func makeStorage() -> sockaddr_storage` from https://github.com/swhitty/FlyingFox/pull/109 has been moved to unit tests.