### PR TITLE
ConsumingAsyncSequence (used in unit tests)

### DIFF
--- a/FlyingFox/Tests/AsyncSequence+ExtensionsTests.swift
+++ b/FlyingFox/Tests/AsyncSequence+ExtensionsTests.swift
@@ -39,7 +39,7 @@ final class AsyncSequenceExtensionTests: XCTestCase {
         var iterator = ConsumingAsyncSequence("fish,chips".data(using: .utf8)!)
             .collectStrings(separatedBy: ",")
             .makeAsyncIterator()
-
+//
         await AsyncAssertEqual(try await iterator.next(), "fish")
         await AsyncAssertEqual(try await iterator.next(), "chips")
         await AsyncAssertEqual(try await iterator.next(), nil)
@@ -66,8 +66,8 @@ final class AsyncSequenceExtensionTests: XCTestCase {
     }
 
     func testTakeNextThrowsError_WhenSequenceEnds() async {
-        let sequence = ConsumingAsyncSequence<Int>([])
-      
+        let sequence = ConsumingAsyncSequence(bytes: [])
+
         await AsyncAssertThrowsError(try await sequence.takeNext(), of: SequenceTerminationError.self)
     }
 }

--- a/FlyingFox/Tests/HTTPBodySequenceTests.swift
+++ b/FlyingFox/Tests/HTTPBodySequenceTests.swift
@@ -213,8 +213,8 @@ final class HTTPBodySequenceTests: XCTestCase {
 
     func testSequencePayload_IsFlushed() async {
         // given
-        let buffer = ConsumingAsyncSequence<UInt8>(
-            [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
+        let buffer = ConsumingAsyncSequence(
+            bytes: [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
         )
 
         let sequence = HTTPBodySequence(from: buffer, count: 10)

--- a/FlyingFox/Tests/HTTPRequestTests.swift
+++ b/FlyingFox/Tests/HTTPRequestTests.swift
@@ -48,8 +48,8 @@ final class HTTPResponseTests: XCTestCase {
 
     func testSequenceBodyData() async {
         // given
-        let buffer = ConsumingAsyncSequence<UInt8>(
-            [0x5, 0x6]
+        let buffer = ConsumingAsyncSequence(
+            bytes: [0x5, 0x6]
         )
         let sequence = HTTPBodySequence(from: buffer, count: 2, suggestedBufferSize: 2)
         let response = HTTPResponse.make(body: sequence)

--- a/FlyingSocks/Sources/AllocatedLock.swift
+++ b/FlyingSocks/Sources/AllocatedLock.swift
@@ -72,6 +72,13 @@ package extension AllocatedLock where State == Void {
     }
 }
 
+package extension AllocatedLock {
+
+    func copy() -> State {
+        withLock { $0 }
+    }
+}
+
 #if canImport(Darwin)
 
 import struct os.os_unfair_lock_t

--- a/FlyingSocks/Tests/AsyncDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncDataSequenceTests.swift
@@ -142,8 +142,8 @@ final class AsyncDataSequenceTests: XCTestCase {
 
     func testIsFlushed_FromStart() async {
         // given
-        let buffer = ConsumingAsyncSequence<UInt8>(
-            [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
+        let buffer = ConsumingAsyncSequence(
+            bytes: [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
         )
         let sequence = AsyncDataSequence(from: buffer, count: 10, chunkSize: 2)
 
@@ -161,8 +161,8 @@ final class AsyncDataSequenceTests: XCTestCase {
 
     func testIsFlushed_FromEnd() async {
         // given
-        let buffer = ConsumingAsyncSequence<UInt8>(
-            [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
+        let buffer = ConsumingAsyncSequence(
+            bytes: [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
         )
         let sequence = AsyncDataSequence(from: buffer, count: 10, chunkSize: 2)
         await AsyncAssertNoThrow(
@@ -183,8 +183,8 @@ final class AsyncDataSequenceTests: XCTestCase {
 
     func testIsFlushed_FromMiddle() async {
         // given
-        let buffer = ConsumingAsyncSequence<UInt8>(
-            [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
+        let buffer = ConsumingAsyncSequence(
+            bytes: [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]
         )
         let sequence = AsyncDataSequence(from: buffer, count: 10, chunkSize: 2)
         await AsyncAssertNoThrow(


### PR DESCRIPTION
Updates `ConsumingAsyncSequence` which is only used in unit tests.  It now wraps `any AsyncBufferedSequence` allowing it to be used with more sequences