### PR TITLE
AsyncBufferedFileSequence (used in HTTPResponses to large files)

### DIFF
--- a/FlyingFox/Tests/HTTPBodySequenceTests.swift
+++ b/FlyingFox/Tests/HTTPBodySequenceTests.swift
@@ -231,20 +231,10 @@ final class HTTPBodySequenceTests: XCTestCase {
         XCTAssertEqual(buffer.index, 10)
     }
 
-    func testFilePayloadCanReplay_WhenSmallerThenMax() async throws {
-        let sequence = try HTTPBodySequence(file: .fishJSON, maxSizeForComplete: 10000, suggestedBufferSize: 1)
+    func testFilePayloadCanReplay() async throws {
+        let sequence = try HTTPBodySequence(file: .fishJSON, suggestedBufferSize: 1)
 
         XCTAssertTrue(sequence.canReplay)
-        await AsyncAssertEqual(
-            try await sequence.get(),
-            try Data(contentsOf: .fishJSON)
-        )
-    }
-
-    func testFilePayloadCanNotReplay_WhenLargerThenMax() async throws {
-        let sequence = try HTTPBodySequence(file: .fishJSON,  maxSizeForComplete: 1, suggestedBufferSize: 1)
-
-        XCTAssertFalse(sequence.canReplay)
         await AsyncAssertEqual(
             try await sequence.get(),
             try Data(contentsOf: .fishJSON)

--- a/FlyingSocks/Sources/AsyncBufferedFileSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedFileSequence.swift
@@ -1,0 +1,104 @@
+//
+//  AsyncBufferedFileSequence.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 06/06/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+package struct AsyncBufferedFileSequence: AsyncBufferedSequence {
+    package typealias Element = UInt8
+
+    private let fileURL: URL
+
+    package init(contentsOf fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    package func makeAsyncIterator() -> Iterator {
+        Iterator(fileURL: fileURL)
+    }
+
+    package struct Iterator: AsyncBufferedIteratorProtocol {
+
+        private let fileURL: URL
+        private var fileHandle: FileHandle?
+
+        init(fileURL: URL) {
+            self.fileURL = fileURL
+        }
+
+        private mutating func makeOrGetFileHandle() throws -> FileHandle {
+            guard let fileHandle else {
+                let handle = try FileHandle(forReadingFrom: fileURL)
+                self.fileHandle = handle
+                return handle
+            }
+            return fileHandle
+        }
+
+        package mutating func next() async throws -> UInt8? {
+            try makeOrGetFileHandle().read(suggestedCount: 1)?.first
+        }
+
+        package mutating func nextBuffer(suggested count: Int) async throws -> Data? {
+            try makeOrGetFileHandle().read(suggestedCount: count)
+        }
+    }
+}
+
+extension AsyncBufferedFileSequence: Sendable { }
+
+extension FileHandle {
+
+    func read(suggestedCount count: Int, forceLegacy: Bool = false) throws -> Data? {
+        if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, *), !forceLegacy {
+            return try read(upToCount: count)
+        } else {
+            return readData(ofLength: count)
+        }
+    }
+}
+
+package extension AsyncBufferedFileSequence {
+
+    static func fileSize(at url: URL) throws -> Int {
+        try fileSize(from: FileManager.default.attributesOfItem(atPath: url.path))
+    }
+
+    internal static func fileSize(from att: [FileAttributeKey: Any]) throws -> Int {
+        guard let size = att[.size] as? UInt64 else {
+            throw FileSizeError()
+        }
+        return Int(size)
+    }
+
+    internal struct FileSizeError: LocalizedError {
+        package var errorDescription: String? = "File size not found"
+    }
+}

--- a/FlyingSocks/Sources/AsyncBufferedSequence+Extensions.swift
+++ b/FlyingSocks/Sources/AsyncBufferedSequence+Extensions.swift
@@ -1,9 +1,9 @@
 //
-//  HTTPRequest+Mock.swift
+//  AsyncBufferedSequence+Extensions.swift
 //  FlyingFox
 //
-//  Created by Simon Whitty on 18/02/2022.
-//  Copyright © 2022 Simon Whitty. All rights reserved.
+//  Created by Simon Whitty on 06/08/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
 //
 //  Distributed under the permissive MIT license
 //  Get the latest version from here:
@@ -29,33 +29,16 @@
 //  SOFTWARE.
 //
 
-@testable import FlyingFox
 import Foundation
 
-extension HTTPRequest {
-    static func make(method: HTTPMethod = .GET,
-                     version: HTTPVersion = .http11,
-                     path: String = "/",
-                     query: [QueryItem] = [],
-                     headers: [HTTPHeader: String] = [:],
-                     body: Data = Data(),
-                     remoteAddress: Address? = nil) -> Self {
-        HTTPRequest(method: method,
-                    version: version,
-                    path: path,
-                    query: query,
-                    headers: headers,
-                    body:  HTTPBodySequence(data: body),
-                    remoteAddress: remoteAddress)
-    }
+package extension AsyncBufferedSequence where Element == UInt8 {
 
-    static func make(method: HTTPMethod = .GET, _ url: String, headers: [HTTPHeader: String] = [:]) -> Self {
-        let (path, query) = HTTPDecoder().readComponents(from: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
-        return HTTPRequest.make(
-            method: method,
-            path: path,
-            query: query,
-            headers: headers
-        )
+    func getAllData(suggestedBuffer count: Int = 4096) async throws -> Data {
+        var data = Data()
+        var iterator = makeAsyncIterator()
+        while let buffer = try await iterator.nextBuffer(suggested: count) {
+            data.append(contentsOf: buffer)
+        }
+        return data
     }
 }

--- a/FlyingSocks/Tests/AsyncBufferedFileSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncBufferedFileSequenceTests.swift
@@ -1,0 +1,79 @@
+//
+//  AsyncBufferedFileSequenceTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 06/08/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingSocks
+import Foundation
+import XCTest
+
+final class AsyncBufferedFileSequenceTests: XCTestCase {
+
+    func testFileSize() {
+        XCTAssertEqual(
+            try AsyncBufferedFileSequence.fileSize(at: .jackOfHeartsRecital),
+            299
+        )
+        XCTAssertThrowsError(
+            try AsyncBufferedFileSequence.fileSize(at: URL(fileURLWithPath: "missing"))
+        )
+
+        XCTAssertThrowsError(
+            try AsyncBufferedFileSequence.fileSize(from: [:])
+        )
+    }
+
+    func testFileHandleRead() throws {
+        let handle = try FileHandle(forReadingFrom: .jackOfHeartsRecital)
+        XCTAssertEqual(
+            try handle.read(suggestedCount: 14, forceLegacy: false),
+            "Two doors down".data(using: .utf8)
+        )
+        XCTAssertEqual(
+            try handle.read(suggestedCount: 9, forceLegacy: true),
+            " the boys".data(using: .utf8)
+        )
+    }
+
+    func testReadsEntireFile() async {
+        let sequence = AsyncBufferedFileSequence(contentsOf: .jackOfHeartsRecital)
+
+        await AsyncAssertEqual(
+            try await sequence.getAllData(),
+            try Data(contentsOf: .jackOfHeartsRecital)
+        )
+    }
+}
+
+private extension URL {
+    static var jackOfHeartsRecital: URL {
+        Bundle.module.url(forResource: "Resources", withExtension: nil)!
+            .appendingPathComponent("JackOfHeartsRecital.txt")
+    }
+}

--- a/FlyingSocks/Tests/AsyncDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncDataSequenceTests.swift
@@ -202,42 +202,6 @@ final class AsyncDataSequenceTests: XCTestCase {
         // then
         XCTAssertEqual(buffer.index, 10)
     }
-
-    func testFileCount() throws {
-        let sequence = try AsyncDataSequence.make(file: .jackOfHeartsRecital, chunkSize: 100)
-        XCTAssertEqual(sequence.count, 299)
-    }
-
-    func testFile_IsReturnedInChunks() async throws {
-        let sequence = try AsyncDataSequence.make(file: .jackOfHeartsRecital, chunkSize: 100)
-        var iterator = sequence.makeAsyncIterator()
-
-        await AsyncAssertEqual(
-            try await iterator.next()?.count,
-            100
-        )
-
-        await AsyncAssertEqual(
-            try await iterator.next()?.count,
-            100
-        )
-
-        await AsyncAssertEqual(
-            try await iterator.next()?.count,
-            99
-        )
-
-        await AsyncAssertNil(
-            try await iterator.next()
-        )
-    }
-}
-
-private extension URL {
-    static var jackOfHeartsRecital: URL {
-        Bundle.module.url(forResource: "Resources", withExtension: nil)!
-            .appendingPathComponent("JackOfHeartsRecital.txt")
-    }
 }
 
 extension AsyncDataSequence {
@@ -246,14 +210,6 @@ extension AsyncDataSequence {
         AsyncDataSequence(
             from: ConsumingAsyncSequence(bytes),
             count: count ?? bytes.count,
-            chunkSize: chunkSize
-        )
-    }
-
-    static func make(file url: URL, chunkSize: Int = 2) throws -> Self {
-        try AsyncDataSequence(
-            file: FileHandle(forReadingFrom: url),
-            count: AsyncDataSequence.size(of: url),
             chunkSize: chunkSize
         )
     }


### PR DESCRIPTION
Adds a dedicated `AsyncBufferedFileSequence` used within `HTTPResponse` when returning large files.  The sequence replaces some legacy logic in the soon to be removed `AsyncDataSequence`