### PR TITLE
Official Swift 6.0 Docker Image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
   linux_swift_6_0:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-jammy
+    container: swift:6.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -33,8 +33,26 @@ let package = Package(
         .target(
              name: "CSystemLinux",
              path: "CSystemLinux"
-        )
-    ] + .testingTargets
+        ),
+        .testTarget(
+             name: "FlyingFoxTests",
+             dependencies: ["FlyingFox"],
+             path: "FlyingFox/Tests",
+             resources: [
+                 .copy("Stubs")
+             ],
+             swiftSettings: .upcomingFeatures
+        ),
+        .testTarget(
+             name: "FlyingSocksTests",
+             dependencies: ["FlyingSocks"],
+             path: "FlyingSocks/Tests",
+             resources: [
+                 .copy("Resources")
+             ],
+             swiftSettings: .upcomingFeatures
+         )
+    ]
 )
 
 extension Array where Element == SwiftSetting {
@@ -43,31 +61,6 @@ extension Array where Element == SwiftSetting {
         [
             .enableUpcomingFeature("ExistentialAny"),
             .swiftLanguageMode(.v6)
-        ]
-    }
-}
-
-extension [PackageDescription.Target] {
-    static var testingTargets: [PackageDescription.Target] {
-        [
-            .testTarget(
-                name: "FlyingFoxTests",
-                dependencies: ["FlyingFox"],
-                path: "FlyingFox/Tests",
-                resources: [
-                    .copy("Stubs")
-                ],
-                swiftSettings: .upcomingFeatures
-            ),
-            .testTarget(
-                name: "FlyingSocksTests",
-                dependencies: ["FlyingSocks"],
-                path: "FlyingSocks/Tests",
-                resources: [
-                    .copy("Resources")
-                ],
-                swiftSettings: .upcomingFeatures
-            )
         ]
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -31,27 +31,27 @@ let package = Package(
             swiftSettings: .upcomingFeatures
         ),
         .target(
-             name: "CSystemLinux",
-             path: "CSystemLinux"
+            name: "CSystemLinux",
+            path: "CSystemLinux"
         ),
         .testTarget(
-             name: "FlyingFoxTests",
-             dependencies: ["FlyingFox"],
-             path: "FlyingFox/Tests",
-             resources: [
-                 .copy("Stubs")
-             ],
-             swiftSettings: .upcomingFeatures
+            name: "FlyingFoxTests",
+            dependencies: ["FlyingFox"],
+            path: "FlyingFox/Tests",
+            resources: [
+               .copy("Stubs")
+            ],
+            swiftSettings: .upcomingFeatures
         ),
         .testTarget(
-             name: "FlyingSocksTests",
-             dependencies: ["FlyingSocks"],
-             path: "FlyingSocks/Tests",
-             resources: [
-                 .copy("Resources")
-             ],
-             swiftSettings: .upcomingFeatures
-         )
+            name: "FlyingSocksTests",
+            dependencies: ["FlyingSocks"],
+            path: "FlyingSocks/Tests",
+            resources: [
+               .copy("Resources")
+            ],
+            swiftSettings: .upcomingFeatures
+        )
     ]
 )
 

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,7 @@ extension Array where Element == SwiftSetting {
 
 extension [PackageDescription.Target] {
     static var testingTargets: [PackageDescription.Target] {
+        [
             .testTarget(
                 name: "FlyingFoxTests",
                 dependencies: ["FlyingFox"],

--- a/Package.swift
+++ b/Package.swift
@@ -49,8 +49,6 @@ extension Array where Element == SwiftSetting {
 
 extension [PackageDescription.Target] {
     static var testingTargets: [PackageDescription.Target] {
-    #if canImport(Darwin) || compiler(>=6.1)
-        [
             .testTarget(
                 name: "FlyingFoxTests",
                 dependencies: ["FlyingFox"],
@@ -70,27 +68,5 @@ extension [PackageDescription.Target] {
                 swiftSettings: .upcomingFeatures
             )
         ]
-        #else
-        [
-            .testTarget(
-                name: "FlyingFoxXCTests",
-                dependencies: ["FlyingFox"],
-                path: "FlyingFox/XCTests",
-                resources: [
-                    .copy("Stubs")
-                ],
-                swiftSettings: .upcomingFeatures
-            ),
-            .testTarget(
-                name: "FlyingSocksXCTests",
-                dependencies: ["FlyingSocks"],
-                path: "FlyingSocks/XCTests",
-                resources: [
-                    .copy("Resources")
-                ],
-                swiftSettings: .upcomingFeatures
-            )
-        ]
-        #endif
     }
 }


### PR DESCRIPTION
Updates GitHub Actions to use the official `swift:6.0` docker image

Enables Swift Testing when using Swift 6 on linux.