### PR TITLE
rename HTTPServer.start() -> run()

### DIFF
--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -89,7 +89,7 @@ public final actor HTTPServer {
         handlers.appendRoute(route, handler: handler)
     }
 
-    public func start() async throws {
+    public func run() async throws {
         guard state == nil else {
             logger.logCritical("server error: already started")
             throw SocketError.unsupportedAddress
@@ -107,6 +107,11 @@ public final actor HTTPServer {
             }
             throw error
         }
+    }
+
+    @available(*, deprecated, renamed: "run")
+    public func start() async throws {
+        try await run()
     }
 
     func preparePoolAndSocket() async throws -> Socket {

--- a/FlyingFox/Tests/HTTPClientTests.swift
+++ b/FlyingFox/Tests/HTTPClientTests.swift
@@ -42,7 +42,7 @@ struct HTTPClientTests {
     func client_sends_request() async throws {
         // given
         let server = HTTPServer(address: .loopback(port: 0))
-        let task = Task { try await server.start() }
+        let task = Task { try await server.run() }
         defer { task.cancel() }
         let client = _HTTPClient()
 

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -45,7 +45,7 @@ actor HTTPServerTests {
         self.stopServer = server
         Task {
             try await HTTPServer.$preferConnectionsDiscarding.withValue(preferConnectionsDiscarding) {
-                try await server.start()
+                try await server.run()
             }
         }
         return try await server.waitForListeningPort()
@@ -54,7 +54,7 @@ actor HTTPServerTests {
     @discardableResult
     func startServer(_ server: HTTPServer) async throws -> Task<Void, any Error> {
         self.stopServer = server
-        let task = Task { try await server.start() }
+        let task = Task { try await server.run() }
         try await server.waitUntilListening()
         return task
     }
@@ -69,7 +69,7 @@ actor HTTPServerTests {
         try await startServer(server)
 
         await #expect(throws: SocketError.unsupportedAddress) {
-            try await server.start()
+            try await server.run()
         }
     }
 
@@ -93,9 +93,9 @@ actor HTTPServerTests {
         defer { try! socket.close() }
 
         await #expect(throws: SocketError.self) {
-            try await server.start()
+            try await server.run()
         }
-//        await AsyncAssertThrowsError(try await server.start(), of: SocketError.self) {
+//        await AsyncAssertThrowsError(try await server.run(), of: SocketError.self) {
 //            XCTAssertTrue(
 //                $0.errorDescription?.contains("Address already in use") == true
 //            )
@@ -430,7 +430,7 @@ actor HTTPServerTests {
             return true
         }
 
-        Task { try await server.start() }
+        Task { try await server.run() }
         self.stopServer = server
 
         #expect(try await waiting.value == true)

--- a/FlyingFox/XCTests/HTTPClientTests.swift
+++ b/FlyingFox/XCTests/HTTPClientTests.swift
@@ -41,7 +41,7 @@ final class HTTPClientTests: XCTestCase {
     func testClient() async throws {
         // given
         let server = HTTPServer(address: .loopback(port: 0))
-        let task = Task { try await server.start() }
+        let task = Task { try await server.run() }
         defer { task.cancel() }
         let client = _HTTPClient()
 

--- a/FlyingFox/XCTests/HTTPServerTests.swift
+++ b/FlyingFox/XCTests/HTTPServerTests.swift
@@ -45,7 +45,7 @@ final class HTTPServerTests: XCTestCase {
         self.stopServer = server
         Task {
             try await HTTPServer.$preferConnectionsDiscarding.withValue(preferConnectionsDiscarding) {
-                try await server.start()
+                try await server.run()
             }
         }
         return try await server.waitForListeningPort()
@@ -54,7 +54,7 @@ final class HTTPServerTests: XCTestCase {
     @discardableResult
     func startServer(_ server: HTTPServer) async throws -> Task<Void, any Error> {
         self.stopServer = server
-        let task = Task { try await server.start() }
+        let task = Task { try await server.run() }
         try await server.waitUntilListening()
         return task
     }
@@ -67,7 +67,7 @@ final class HTTPServerTests: XCTestCase {
         let server = HTTPServer.make()
         try await startServer(server)
 
-        await AsyncAssertThrowsError(try await server.start(), of: SocketError.self) {
+        await AsyncAssertThrowsError(try await server.run(), of: SocketError.self) {
             XCTAssertEqual($0, .unsupportedAddress)
         }
     }
@@ -89,7 +89,7 @@ final class HTTPServerTests: XCTestCase {
         let socket = try await server.makeSocketAndListen()
         defer { try! socket.close() }
 
-        await AsyncAssertThrowsError(try await server.start(), of: SocketError.self) {
+        await AsyncAssertThrowsError(try await server.run(), of: SocketError.self) {
             XCTAssertTrue(
                 $0.errorDescription?.contains("Address already in use") == true
             )
@@ -405,7 +405,7 @@ final class HTTPServerTests: XCTestCase {
             return true
         }
 
-        Task { try await server.start() }
+        Task { try await server.run() }
         self.stopServer = server
 
         await AsyncAssertEqual(try await waiting.value, true)

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Start the server by providing a port number:
 import FlyingFox
 
 let server = HTTPServer(port: 80)
-try await server.start()
+try await server.run()
 ```
 
 The server runs within the the current task. To stop the server, cancel the task terminating all connections immediatley:
 
 ```swift
-let task = Task { try await server.start() }
+let task = Task { try await server.run() }
 task.cancel()
 ```
 
@@ -72,7 +72,7 @@ Retrieve the current listening address:
 await server.listeningAddress
 ```
 
-> Note: iOS will hangup the listening socket when an app is suspended in the background. Once the app returns to the foreground, `HTTPServer.start()` detects this, throwing `SocketError.disconnected`. The server must then be started once more.
+> Note: iOS will hangup the listening socket when an app is suspended in the background. Once the app returns to the foreground, `HTTPServer.run()` detects this, throwing `SocketError.disconnected`. The server must then be started once more.
 
 ## Handlers
 
@@ -360,7 +360,7 @@ struct MyHandler {
 }
 
 let server = HTTPServer(port: 80, handler: MyHandler())
-try await server.start()
+try await server.run()
 ```
 
 The annotations are implemented via [SE-0389 Attached Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0389-attached-macros.md).


### PR DESCRIPTION
Deprecates `HTTPServer.start()` and offers the renamed `HTTPServer.run()`  for compatibility with [swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle)