### PR TITLE
convert setPktInfo() to SocketOption

### DIFF
--- a/FlyingSocks/Tests/SocketTests.swift
+++ b/FlyingSocks/Tests/SocketTests.swift
@@ -321,6 +321,45 @@ struct SocketTests {
             try Socket.inet_ntop(AF_INET6, &addr.sin6_addr, buffer, maxLength)
         }
     }
+
+    @Test
+    func makes_datagram_ip4() throws {
+        #expect(throws: Never.self) {
+            try Socket(domain: Int32(sa_family_t(AF_INET)), type: .datagram)
+        }
+    }
+
+    @Test
+    func makes_datagram_ip6() throws {
+        #expect(throws: Never.self) {
+            try Socket(domain: Int32(sa_family_t(AF_INET6)), type: .datagram)
+        }
+    }
+
+    @Test
+    func packetInfoIP() throws {
+        let socket = try Socket(domain: Int32(sa_family_t(AF_INET)), type: .datagram)
+        #expect(
+            try socket.getValue(for: .packetInfoIP) == false
+        )
+
+        try socket.setValue(true, for: .packetInfoIP)
+        #expect(
+            try socket.getValue(for: .packetInfoIP) == true
+        )
+    }
+
+    @Test
+    func packetInfoIPv6() throws {
+        let socket = try Socket(domain: Int32(sa_family_t(AF_INET6)), type: .datagram)
+
+        withKnownIssue("Permission denied error is thrown") {
+            try socket.setValue(true, for: .packetInfoIPv6)
+            #expect(
+                try socket.getValue(for: .packetInfoIPv6) == true
+            )
+        }
+    }
 }
 
 extension Socket.Flags {


### PR DESCRIPTION
There is currently an issue on the main branch where constructing a UDP socket with IP6 fails every time on both Darwin and Linux:

```swift
try Socket(domain: AF_INET6, type: .datagram)
```

Darin: `SocketError.failed(type: "SetOption", errno: 13, message: "Permission denied")`
Linux: `SocketError.failed(type: "SetPktInfoOption", errno: 22, message: "Invalid argument")`

While this PR does not fix the underlying issue, it moves the logic from `init()` so sockets  can opt in to setting the packet info allowing users to sidestep the issue.

The `private func setPktInfo()` has now been removed completely as some[ recent refactoring](https://github.com/swhitty/FlyingFox/pull/130) allows these options to be set via the existing `protocol SocketOption` / `setValue()` API.

Users now enable the packet info options like so:

```swift
let socket = try Socket(domain: AF_INET, type: .datagram)
try socket.setValue(true, for: .packetInfoIP)
```

Unit tests have been added to cover this case, and because it still fails when using IPv6 the tests currently assert expected failures.