### PR TITLE
convert setPktInfo() to SocketOption

### DIFF
--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -123,24 +123,13 @@ public struct Socket: Sendable, Hashable {
 
     // enable return of ip_pktinfo/ipv6_pktinfo on recvmsg()
     private func setPktInfo(domain: Int32) throws {
-        var enable = Int32(1)
-        let level: Int32
-        let name: Int32
-
         switch domain {
         case AF_INET:
-            level = Socket.ipproto_ip
-            name = Self.ip_pktinfo
+            try setValue(true, for: .packetInfoIP)
         case AF_INET6:
-            level = Socket.ipproto_ipv6
-            name = Self.ipv6_recvpktinfo
+            try setValue(true, for: .packetInfoIPv6)
         default:
             return
-        }
-
-        let result = Socket.setsockopt(file.rawValue, level, name, &enable, socklen_t(MemoryLayout<Int32>.size))
-        guard result >= 0 else {
-            throw SocketError.makeFailed("SetPktInfoOption")
         }
     }
 
@@ -571,6 +560,14 @@ public struct Int32SocketOption: SocketOption {
 public extension SocketOption where Self == BoolSocketOption {
     static var localAddressReuse: Self {
         BoolSocketOption(name: SO_REUSEADDR)
+    }
+
+    static var packetInfoIP: Self {
+        BoolSocketOption(level: Socket.ipproto_ip, name: Socket.ip_pktinfo)
+    }
+
+    static var packetInfoIPv6: Self {
+        BoolSocketOption(level: Socket.ipproto_ipv6, name: Socket.ipv6_recvpktinfo)
     }
 
     #if canImport(Darwin)

--- a/FlyingSocks/Tests/SocketTests.swift
+++ b/FlyingSocks/Tests/SocketTests.swift
@@ -321,6 +321,24 @@ struct SocketTests {
             try Socket.inet_ntop(AF_INET6, &addr.sin6_addr, buffer, maxLength)
         }
     }
+
+    @Test
+    func makes_datagram_ip4() throws {
+        let socket = try Socket(domain: Int32(sa_family_t(AF_INET)), type: .datagram)
+
+        #expect(
+            try socket.getValue(for: .packetInfoIP) == true
+        )
+    }
+
+    @Test
+    func makes_datagram_ip6() throws {
+        let socket = try Socket(domain: Int32(sa_family_t(AF_INET6)), type: .datagram)
+
+        #expect(
+            try socket.getValue(for: .packetInfoIPv6) == true
+        )
+    }
 }
 
 extension Socket.Flags {

--- a/FlyingSocks/XCTests/SocketTests.swift
+++ b/FlyingSocks/XCTests/SocketTests.swift
@@ -258,6 +258,20 @@ final class SocketTests: XCTestCase {
         let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: Int(maxLength))
         XCTAssertThrowsError(try Socket.inet_ntop(AF_INET6, &addr.sin6_addr, buffer, maxLength))
     }
+
+    func testMakes_datagram_ip4() throws {
+        let socket = try Socket(domain: Int32(sa_family_t(AF_INET)), type: .datagram)
+        XCTAssertTrue(
+            try socket.getValue(for: .packetInfoIP)
+        )
+    }
+
+    func testMakes_datagram_ip6() throws {
+        let socket = try Socket(domain: Int32(sa_family_t(AF_INET6)), type: .datagram)
+        XCTAssertTrue(
+            try socket.getValue(for: .packetInfoIPv6)
+        )
+    }
 }
 
 extension Socket.Flags {


### PR DESCRIPTION
After some[ recent refactoring](https://github.com/swhitty/FlyingFox/pull/130) we can now get and set the packetInfo via the existing the existing `protocol SocketOption` / `setValue()` API.

UDP sockets still enable these options by default within `.init()` but users can now easily read and change the values like so:

```swift
let socket = try Socket(domain: AF_INET, type: .datagram)
try socket.getValue(for: .packetInfoIP) == true

try socket.setValue(false, for: .packetInfoIP)
try socket.getValue(for: .packetInfoIP) == false
```

Unit tests have been added to cover this case.