### PR TITLE
Android SDK build within GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,3 +118,16 @@ jobs:
         run: swift sdk list
       - name: Build
         run: swift build --swift-sdk x86_64-swift-linux-musl
+
+  linux_swift_6_0_android:
+    runs-on: ubuntu-latest
+    container: swift:6.0.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Version
+        run: swift --version
+      - name: Install SDK
+        run: swift sdk install https://github.com/finagolfin/swift-android-sdk/releases/download/6.0.2/swift-6.0.2-RELEASE-android-24-0.1.artifactbundle.tar.gz --checksum  d75615eac3e614131133c7cc2076b0b8fb4327d89dce802c25cd53e75e1881f4
+      - name: Build
+        run: swift build --swift-sdk aarch64-unknown-linux-android24


### PR DESCRIPTION
Support for building with an Android SDK was added by @lhoward within https://github.com/swhitty/FlyingFox/pull/127.

This PR updates the GitHub actions config to include an additional build using the Android using [swift-android-sdk](https://github.com/finagolfin/swift-android-sdk) by @finagolfin 🙏🏻.

