### PR TITLE
remove AnySocketAddress

### DIFF
--- a/FlyingSocks/Sources/AsyncSocket.swift
+++ b/FlyingSocks/Sources/AsyncSocket.swift
@@ -231,7 +231,7 @@ public struct AsyncSocket: Sendable {
         message: [UInt8],
         to peerAddress: some SocketAddress,
         interfaceIndex: UInt32? = nil,
-        from localAddress: (some SocketAddress)? = nil
+        from localAddress: (any SocketAddress)? = nil
     ) async throws {
         let sent = try await pool.loopUntilReady(for: .write, on: socket) {
             try socket.send(message: message, to: peerAddress, interfaceIndex: interfaceIndex, from: localAddress)
@@ -251,19 +251,11 @@ public struct AsyncSocket: Sendable {
     }
 
     public func send(message: Message) async throws {
-        let localAddress: AnySocketAddress?
-
-        if let unwrappedLocalAddress = message.localAddress {
-            localAddress = AnySocketAddress(unwrappedLocalAddress)
-        } else {
-            localAddress = nil
-        }
-
         try await send(
             message: message.bytes,
             to: AnySocketAddress(message.peerAddress),
             interfaceIndex: message.interfaceIndex,
-            from: localAddress
+            from: message.localAddress
         )
     }
 #endif

--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -397,7 +397,7 @@ public struct Socket: Sendable, Hashable {
         message: [UInt8],
         to peerAddress: some SocketAddress,
         interfaceIndex: UInt32? = nil,
-        from localAddress: (some SocketAddress)? = nil
+        from localAddress: (any SocketAddress)? = nil
     ) throws -> Int {
         try message.withUnsafeBytes { buffer in
             try send(
@@ -417,7 +417,7 @@ public struct Socket: Sendable, Hashable {
         flags: Int32,
         to peerAddress: some SocketAddress,
         interfaceIndex: UInt32? = nil,
-        from localAddress: (some SocketAddress)? = nil
+        from localAddress: (any SocketAddress)? = nil
     ) throws -> Int {
         var iov = iovec()
         var msg = msghdr()
@@ -685,7 +685,7 @@ fileprivate extension Socket {
     static func withPacketInfoControl<T>(
         family: sa_family_t,
         interfaceIndex: UInt32?,
-        address: (some SocketAddress)?,
+        address: (any SocketAddress)?,
         _ body: (UnsafePointer<cmsghdr>?, ControlMessageHeaderLengthType) -> T
     ) -> T {
         switch Int32(family) {


### PR DESCRIPTION
`struct AnySocketAddress` should not be needed as `any SocketAddress` can box all addresses and can then be unwrapped to `sockaddr_storage` when required to be used.

replace `(some SocketAddress)? = nil` with `(any SocketAddress)? = nil` so callers of this method do not need to provide a concrete type and can instead provide `nil`