### PR TITLE
Fix HTTPBodySequence for large requests (adds AsyncBufferedPrefixSequence)

### DIFF
--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -122,16 +122,9 @@ struct HTTPDecoder {
         if length <= sharedRequestReplaySize {
             return HTTPBodySequence(shared: bytes, count: length, suggestedBufferSize: 4096)
         } else {
-            return HTTPBodySequence(from: bytes, count: length, suggestedBufferSize: 4096)
+            let prefix = AsyncBufferedPrefixSequence(base: bytes, count: length)
+            return HTTPBodySequence(from: prefix, count: length, suggestedBufferSize: 4096)
         }
-    }
-
-    func makeBodyData(from bytes: some AsyncBufferedSequence<UInt8>, length: Int) async throws -> Data {
-        var iterator = bytes.makeAsyncIterator()
-        guard let buffer = try await iterator.nextBuffer(count: length) else {
-            throw Error("AsyncBufferedSequence prematurely ended")
-        }
-        return Data(buffer)
     }
 }
 

--- a/FlyingSocks/Sources/AsyncBufferedPrefixSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedPrefixSequence.swift
@@ -30,6 +30,8 @@
 //
 
 package struct AsyncBufferedPrefixSequence<Base: AsyncBufferedSequence>: AsyncBufferedSequence {
+    package typealias Element = Base.Element
+
     private let base: Base
     private let count: Int
     

--- a/FlyingSocks/Sources/AsyncBufferedPrefixSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedPrefixSequence.swift
@@ -1,0 +1,79 @@
+//
+//  AsyncBufferedPrefixSequence.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 04/02/2025.
+//  Copyright © 2025 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+package struct AsyncBufferedPrefixSequence<Base: AsyncBufferedSequence>: AsyncBufferedSequence {
+    private let base: Base
+    private let count: Int
+    
+    package init(base: Base, count: Int) {
+        self.base = base
+        self.count = count
+    }
+
+    package func makeAsyncIterator() -> Iterator {
+        Iterator(iterator: base.makeAsyncIterator(), remaining: count)
+    }
+
+    package struct Iterator: AsyncBufferedIteratorProtocol {
+        private var iterator: Base.AsyncIterator
+        private var remaining: Int
+
+        init (iterator: Base.AsyncIterator, remaining: Int) {
+            self.iterator = iterator
+            self.remaining = remaining
+        }
+
+        package mutating func next() async throws -> Base.Element? {
+            guard remaining > 0 else { return nil }
+
+            if let element = try await iterator.next() {
+                remaining -= 1
+                return element
+            } else {
+                remaining = 0
+                return nil
+            }
+        }
+
+        package mutating func nextBuffer(suggested count: Int) async throws -> Base.AsyncIterator.Buffer? {
+            guard remaining > 0 else { return nil }
+
+            let count = Swift.min(remaining, count)
+            if let buffer = try await iterator.nextBuffer(suggested: count) {
+                remaining -= buffer.count
+                return buffer
+            } else {
+                remaining = 0
+                return nil
+            }
+        }
+    }
+}

--- a/FlyingSocks/Tests/AsyncBufferedPrefixSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncBufferedPrefixSequenceTests.swift
@@ -1,0 +1,101 @@
+//
+//  AsyncBufferedPrefixSequenceTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 04/02/2025.
+//  Copyright © 2025 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingSocks
+import Foundation
+import Testing
+
+struct AsyncBufferedPrefixSequenceTests {
+
+    @Test
+    func next_terminates_after_count() async throws {
+        let buffer = AsyncBufferedCollection(["a", "b", "c", "d", "e", "f"])
+        var prefix = AsyncBufferedPrefixSequence(base: buffer, count: 4).makeAsyncIterator()
+
+        #expect(
+            try await prefix.next() == "a"
+        )
+        #expect(
+            try await prefix.next() == "b"
+        )
+        #expect(
+            try await prefix.next() == "c"
+        )
+        #expect(
+            try await prefix.next() == "d"
+        )
+        #expect(
+            try await prefix.next() == nil
+        )
+    }
+
+    @Test
+    func nextBuffer_terminates_after_count() async throws {
+        let buffer = AsyncBufferedCollection(["a", "b", "c", "d", "e", "f"])
+        var prefix = AsyncBufferedPrefixSequence(base: buffer, count: 4).makeAsyncIterator()
+
+        #expect(
+            try await prefix.nextBuffer(suggested: 3) == ["a", "b", "c"]
+        )
+        #expect(
+            try await prefix.nextBuffer(suggested: 3) == ["d"]
+        )
+        #expect(
+            try await prefix.nextBuffer(suggested: 3) == nil
+        )
+    }
+
+    @Test
+    func next_terminates_when_base_terminates() async throws {
+        let buffer = AsyncBufferedCollection(["a"])
+        var prefix = AsyncBufferedPrefixSequence(base: buffer, count: 2).makeAsyncIterator()
+
+        #expect(
+            try await prefix.next() == "a"
+        )
+        #expect(
+            try await prefix.next() == nil
+        )
+    }
+
+    @Test
+    func nextBuffer_terminates_when_base_terminates() async throws {
+        let buffer = AsyncBufferedCollection(["a"])
+        var prefix = AsyncBufferedPrefixSequence(base: buffer, count: 10).makeAsyncIterator()
+
+        #expect(
+            try await prefix.nextBuffer(suggested: 3) == ["a"]
+        )
+        #expect(
+            try await prefix.nextBuffer(suggested: 3) == nil
+        )
+    }
+}


### PR DESCRIPTION
fixes https://github.com/swhitty/FlyingFox/issues/139

`HTTPRequest.bodySequence` is aways backed by one of the the following concrete types:

- [`AsyncSharedReplaySequence`](https://github.com/swhitty/FlyingFox/blob/main/FlyingSocks/Sources/AsyncSharedReplaySequence.swift): Sequence that can be safely iterated multiple times by one or more consumers concurrently.  It is buffered in memory and is used for all requests with body less than `2_097_152` bytes https://github.com/swhitty/FlyingFox/blob/fe9437def670a54f17a135135e9c8127cc817962/FlyingFox/Sources/HTTPServer%2BConfiguration.swift#L46

- [`AsyncSocketReadSequence`](https://github.com/swhitty/FlyingFox/blob/fe9437def670a54f17a135135e9c8127cc817962/FlyingSocks/Sources/AsyncSocket.swift#L323) Sequence that is backed directly by the socket itself. Used for all requests with body greater than `2_097_152` bytes.

A bug exists  when `AsyncSocketReadSequence` is used, because the sequence is only terminated when the underlying socket is closed, the sequence hangs when all bytes are read but the socket remains open.

This PR adds `AsyncBufferedPrefixSequence` which wraps the underlying `AsyncSocketReadSequence` terminating the sequence when all bytes have been read.





 