### PR TITLE
Buffer HTTPRequest.body < 4096 bytes as Data

### DIFF
--- a/FlyingFox/Sources/HTTPClient.swift
+++ b/FlyingFox/Sources/HTTPClient.swift
@@ -53,7 +53,7 @@ package extension AsyncSocket {
     }
 
     func readResponse() async throws -> HTTPResponse {
-        try await HTTPDecoder(sharedRequestReplaySize: 102_400).decodeResponse(from: bytes)
+        try await HTTPDecoder(sharedRequestBufferSize: 4096, sharedRequestReplaySize: 102_400).decodeResponse(from: bytes)
     }
 
     func writeFrame(_ frame: WSFrame) async throws {

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -313,11 +313,11 @@ private extension HTTPRoute {
 
     static func readComponents(from path: String) -> (path: String, query: [HTTPRequest.QueryItem]) {
         guard path.removingPercentEncoding == path else {
-            return HTTPDecoder(sharedRequestReplaySize: 0).readComponents(from: path)
+            return HTTPDecoder().readComponents(from: path)
         }
 
         let escaped = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-        return HTTPDecoder(sharedRequestReplaySize: 0).readComponents(from: escaped ?? path)
+        return HTTPDecoder().readComponents(from: escaped ?? path)
     }
 }
 
@@ -377,5 +377,11 @@ public extension Array where Element == HTTPRoute.Parameter {
         get {
             first { $0.name == name }
         }
+    }
+}
+
+private extension HTTPDecoder {
+    init() {
+        self.init(sharedRequestBufferSize: 128, sharedRequestReplaySize: 1024)
     }
 }

--- a/FlyingFox/Sources/HTTPServer+Configuration.swift
+++ b/FlyingFox/Sources/HTTPServer+Configuration.swift
@@ -37,24 +37,26 @@ public extension HTTPServer {
     struct Configuration: Sendable {
         public var address: any SocketAddress
         public var timeout: TimeInterval
+        public var sharedRequestBufferSize: Int
         public var sharedRequestReplaySize: Int
         public var pool: any AsyncSocketPool
         public var logger: any Logging
 
         public init(address: some SocketAddress,
                     timeout: TimeInterval = 15,
+                    sharedRequestBufferSize: Int = 4_096,
                     sharedRequestReplaySize: Int = 2_097_152,
                     pool: any AsyncSocketPool = HTTPServer.defaultPool(),
                     logger: any Logging = HTTPServer.defaultLogger()) {
             self.address = address
             self.timeout = timeout
+            self.sharedRequestBufferSize = sharedRequestBufferSize
             self.sharedRequestReplaySize = sharedRequestReplaySize
             self.pool = pool
             self.logger = logger
         }
     }
 }
-
 
 extension HTTPServer.Configuration {
 

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -208,7 +208,7 @@ public final actor HTTPServer {
     private func makeConnection(socket: AsyncSocket) -> HTTPConnection {
         HTTPConnection(
             socket: socket,
-            decoder: HTTPDecoder(sharedRequestReplaySize: config.sharedRequestReplaySize),
+            decoder: HTTPDecoder(sharedRequestBufferSize: config.sharedRequestBufferSize, sharedRequestReplaySize: config.sharedRequestReplaySize),
             logger: config.logger
         )
     }

--- a/FlyingFox/Tests/HTTPConnectionTests.swift
+++ b/FlyingFox/Tests/HTTPConnectionTests.swift
@@ -149,7 +149,7 @@ private extension HTTPConnection {
     init(socket: AsyncSocket) {
         self.init(
             socket: socket,
-            decoder: HTTPDecoder(sharedRequestReplaySize: 1024),
+            decoder: HTTPDecoder.make(),
             logger: .disabled
         )
     }

--- a/FlyingFox/Tests/HTTPRequest+Mock.swift
+++ b/FlyingFox/Tests/HTTPRequest+Mock.swift
@@ -50,7 +50,7 @@ extension HTTPRequest {
     }
 
     static func make(method: HTTPMethod = .GET, _ url: String, headers: [HTTPHeader: String] = [:]) -> Self {
-        let (path, query) = HTTPDecoder(sharedRequestReplaySize: 0).readComponents(from: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        let (path, query) = HTTPDecoder.make().readComponents(from: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         return HTTPRequest.make(
             method: method,
             path: path,
@@ -63,5 +63,14 @@ extension HTTPRequest {
         get async throws {
             try await String(decoding: bodyData, as: UTF8.self)
         }
+    }
+}
+
+extension HTTPDecoder {
+    static func make(sharedRequestBufferSize: Int = 128, sharedRequestReplaySize: Int = 1024) -> HTTPDecoder {
+        HTTPDecoder(
+            sharedRequestBufferSize: sharedRequestBufferSize,
+            sharedRequestReplaySize: sharedRequestReplaySize
+        )
     }
 }

--- a/FlyingFox/XCTests/HTTPConnectionTests.swift
+++ b/FlyingFox/XCTests/HTTPConnectionTests.swift
@@ -147,7 +147,7 @@ private extension HTTPConnection {
     init(socket: AsyncSocket) {
         self.init(
             socket: socket,
-            decoder: HTTPDecoder(sharedRequestReplaySize: 1024),
+            decoder: HTTPDecoder.make(sharedRequestReplaySize: 1024),
             logger: .disabled
         )
     }

--- a/FlyingFox/XCTests/HTTPRequest+Mock.swift
+++ b/FlyingFox/XCTests/HTTPRequest+Mock.swift
@@ -50,12 +50,21 @@ extension HTTPRequest {
     }
 
     static func make(method: HTTPMethod = .GET, _ url: String, headers: [HTTPHeader: String] = [:]) -> Self {
-        let (path, query) = HTTPDecoder(sharedRequestReplaySize: 0).readComponents(from: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        let (path, query) = HTTPDecoder.make().readComponents(from: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         return HTTPRequest.make(
             method: method,
             path: path,
             query: query,
             headers: headers
+        )
+    }
+}
+
+extension HTTPDecoder {
+    static func make(sharedRequestBufferSize: Int = 128, sharedRequestReplaySize: Int = 1024) -> HTTPDecoder {
+        HTTPDecoder(
+            sharedRequestBufferSize: sharedRequestBufferSize,
+            sharedRequestReplaySize: sharedRequestReplaySize
         )
     }
 }


### PR DESCRIPTION
`HTTPRequest` currently provides access to the body via `HTTPBodySequence`, this sequence is currently backed by 2 concrete sequences:

- [`AsyncSharedReplaySequence`](https://github.com/swhitty/FlyingFox/blob/main/FlyingSocks/Sources/AsyncSharedReplaySequence.swift): Sequence that can be safely iterated multiple times by one or more consumers concurrently.  It is buffered in memory and is used for all requests with body less than `2_097_152` bytes https://github.com/swhitty/FlyingFox/blob/fe9437def670a54f17a135135e9c8127cc817962/FlyingFox/Sources/HTTPServer%2BConfiguration.swift#L46

- [`AsyncSocketReadSequence`](https://github.com/swhitty/FlyingFox/blob/fe9437def670a54f17a135135e9c8127cc817962/FlyingSocks/Sources/AsyncSocket.swift#L323) Sequence that is backed directly by the socket itself. Used for all requests with body greater than `2_097_152` bytes.

This PR adds a 3rd type that can be used for small requests:

- `Data` / [`AsyncBufferedCollection`](https://github.com/swhitty/FlyingFox/blob/main/FlyingSocks/Sources/AsyncBufferedCollection.swift) is now used for small requests with a body less than `4_096` bytes.