### PR TITLE
Update FileHTTPHandler to support partial range requests

### DIFF
--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -69,8 +69,12 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
         )
     }
 
-    public init(file url: URL, suggestedBufferSize: Int = 4096) throws {
-        self.storage = try Storage(fileURL: url, bufferSize: suggestedBufferSize)
+    public init(file url: URL, range: Range<Int>? = nil, suggestedBufferSize: Int = 4096) throws {
+        self.storage = try Storage(
+            fileURL: url,
+            range: range,
+            bufferSize: suggestedBufferSize
+        )
     }
 
     public func makeAsyncIterator() -> Iterator {
@@ -91,9 +95,10 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
             self.canReplay = true
         }
 
-        init(fileURL: URL, bufferSize: Int) throws {
-            self.sequence = AsyncBufferedFileSequence(contentsOf: fileURL)
-            self.count =  try AsyncBufferedFileSequence.fileSize(at: fileURL)
+        init(fileURL: URL, range: Range<Int>?, bufferSize: Int) throws {
+            let fileSequence = try AsyncBufferedFileSequence(contentsOf: fileURL, range: range)
+            self.sequence = fileSequence
+            self.count = fileSequence.count
             self.bufferSize = bufferSize
             self.canReplay = true
         }

--- a/FlyingFox/Sources/HTTPEncoder.swift
+++ b/FlyingFox/Sources/HTTPEncoder.swift
@@ -39,7 +39,8 @@ struct HTTPEncoder {
                       response.statusCode.phrase].joined(separator: " ")
 
         var httpHeaders = response.headers
-        if let contentLength = makeContentLength(from: response.payload) {
+        if let contentLength = makeContentLength(from: response.payload),
+           httpHeaders[.contentLength] == nil {
             httpHeaders[.contentLength] = String(contentLength)
         } else if let encoding = makeTransferEncoding(from: response.payload) {
             httpHeaders.addValue(encoding, for: .transferEncoding)

--- a/FlyingSocks/XCTests/AsyncBufferedFileSequenceTests.swift
+++ b/FlyingSocks/XCTests/AsyncBufferedFileSequenceTests.swift
@@ -61,8 +61,8 @@ final class AsyncBufferedFileSequenceTests: XCTestCase {
         )
     }
 
-    func testReadsEntireFile() async {
-        let sequence = AsyncBufferedFileSequence(contentsOf: .jackOfHeartsRecital)
+    func testReadsEntireFile() async throws {
+        let sequence = try AsyncBufferedFileSequence(contentsOf: .jackOfHeartsRecital)
 
         await AsyncAssertEqual(
             try await sequence.getAllData(),


### PR DESCRIPTION
Updates `FileHTTPHandler` to support partial[ range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests).

Routes for both `GET` and  `HEAD` must be created to a file:

```swift
await server.appendRoute("GET,HEAD /jaws", to: .file(named: "jaws.m4v"))
```

When clients request the route and provide a `range` header

```http
GET /jaws HTTP/1.1
Host: localhost
Range: bytes=41000-49999
```

The response return just the requests bytes;

```http
HTTP/1.1 206 Partial Content
Content-Type: video/mp4
Content-Range: bytes 41000-49999/60000
Content-Length: 9000
Accept-Ranges: bytes
```
