### PR TITLE
Handle offset requests

### DIFF
--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -352,7 +352,8 @@ extension Logging {
     }
 
     func logRequest(_ request: HTTPRequest, on connection: HTTPConnection) {
-        logInfo("\(connection.identifer) request: \(request.method.rawValue) \(request.path)")
+        let suffix = request.headers[.range] != nil ? " <ranged>" : ""
+        logInfo("\(connection.identifer) request: \(request.method.rawValue) \(request.path)\(suffix)")
     }
 
     func logError(_ error: any Error, on connection: HTTPConnection) {

--- a/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
@@ -187,6 +187,15 @@ struct HTTPHandlerTests {
             FileHTTPHandler.makePartialRange(for: [.range: "bytes=1-5"]) == 1...5
         )
         #expect(
+            FileHTTPHandler.makePartialRange(for: [.range: "bytes=0-5100"]) == 0...5100
+        )
+        #expect(
+            FileHTTPHandler.makePartialRange(for: [.range: "bytes=0-"], fileSize: 10) == 0...9
+        )
+        #expect(
+            FileHTTPHandler.makePartialRange(for: [.range: "bytes=2-"], fileSize: 10) == 2...9
+        )
+        #expect(
             FileHTTPHandler.makePartialRange(for: [.range: "bytes = 8 - 10"]) == 8...10
         )
         #expect(
@@ -311,5 +320,11 @@ struct HTTPHandlerTests {
 
         let response = try await handler.handleRequest(.make(path: "/hello"))
         #expect(response.statusCode == .ok)
+    }
+}
+
+private extension FileHTTPHandler {
+    static func makePartialRange(for headers: [HTTPHeader: String]) -> ClosedRange<Int>? {
+        makePartialRange(for: headers, fileSize: 10000)
     }
 }


### PR DESCRIPTION
Extends the HTTP ranged request support added in https://github.com/swhitty/FlyingFox/pull/157 to include support for offset only requests

This PR allows requests optionally provide an end of the range;

```http
GET /jaws HTTP/1.1
Host: localhost
Range: bytes=41000-
```

And a response will return everything to the end of the file.

```http
HTTP/1.1 206 Partial Content
Content-Type: video/mp4
Content-Range: bytes 41000-59999/60000
Content-Length: 19000
Accept-Ranges: bytes
```