### PR TITLE
TimeoutError -> SocketError.timeout

### DIFF
--- a/FlyingSocks/Sources/SocketError.swift
+++ b/FlyingSocks/Sources/SocketError.swift
@@ -39,6 +39,7 @@ public enum SocketError: LocalizedError, Equatable {
     case blocked
     case disconnected
     case unsupportedAddress
+    case timeout(message: String)
 
     public var errorDescription: String? {
         switch self {
@@ -50,6 +51,8 @@ public enum SocketError: LocalizedError, Equatable {
             return "SocketError. Disconnected"
         case .unsupportedAddress:
             return "SocketError. UnsupportedAddress"
+        case .timeout(message: let message):
+            return "SocketError. Timeout: \(message)"
         }
     }
 

--- a/FlyingSocks/Tests/SocketErrorTests.swift
+++ b/FlyingSocks/Tests/SocketErrorTests.swift
@@ -48,6 +48,7 @@ struct SocketErrorTests {
         #expect(SocketError.blocked.errorDescription == "SocketError. Blocked")
         #expect(SocketError.disconnected.errorDescription == "SocketError. Disconnected")
         #expect(SocketError.unsupportedAddress.errorDescription == "SocketError. UnsupportedAddress")
+        #expect(SocketError.timeout(message: "fish").errorDescription == "SocketError. Timeout: fish")
     }
 
     @Test

--- a/FlyingSocks/Tests/Task+TimeoutTests.swift
+++ b/FlyingSocks/Tests/Task+TimeoutTests.swift
@@ -54,7 +54,7 @@ struct TaskTimeoutTests {
         }
 
         // then
-        await #expect(throws: TimeoutError.self) {
+        await #expect(throws: SocketError.makeTaskTimeout(seconds: 0.01)) {
             _ = try await task.value
         }
     }
@@ -109,7 +109,7 @@ struct TaskTimeoutTests {
             try await Task.sleep(seconds: 10)
         }
 
-        await #expect(throws: TimeoutError.self) {
+        await #expect(throws: SocketError.makeTaskTimeout(seconds: 0.1)) {
             try await task.getValue(cancelling: .afterTimeout(seconds: 0.1))
         }
     }
@@ -154,7 +154,7 @@ struct TaskTimeoutTests {
 
     @Test
     func mainActorThrowsError_WhenTimeoutExpires() async {
-        await #expect(throws: TimeoutError.self) { @MainActor in
+        await #expect(throws: SocketError.makeTaskTimeout(seconds: 0.05)) { @MainActor in
             try await withThrowingTimeout(seconds: 0.05) {
                 MainActor.assertIsolated()
                 defer { MainActor.assertIsolated() }
@@ -189,7 +189,7 @@ struct TaskTimeoutTests {
 
     @Test
     func actorThrowsError_WhenTimeoutExpires() async {
-        await #expect(throws: TimeoutError.self) {
+        await #expect(throws: SocketError.makeTaskTimeout(seconds: 0.05)) {
             try await withThrowingTimeout(seconds: 0.05) {
                 try await TestActor().returningValue(after: 60, timeout: 0.05)
             }

--- a/FlyingSocks/XCTests/Task+TimeoutTests.swift
+++ b/FlyingSocks/XCTests/Task+TimeoutTests.swift
@@ -53,9 +53,9 @@ final class TaskTimeoutTests: XCTestCase {
         // then
         do {
             _ = try await task.value
-            XCTFail("Expected TimeoutError")
+            XCTFail("Expected SocketError.timeout")
         } catch {
-            XCTAssertTrue(error is TimeoutError)
+            XCTAssertEqual(error as? SocketError, .makeTaskTimeout(seconds: 0.5))
         }
     }
 
@@ -110,10 +110,13 @@ final class TaskTimeoutTests: XCTestCase {
             try await Task.sleep(seconds: 10)
         }
 
-        await AsyncAssertThrowsError(
-            try await task.getValue(cancelling: .afterTimeout(seconds: 0.1)),
-            of: TimeoutError.self
-        )
+        // then
+        do {
+            try await task.getValue(cancelling: .afterTimeout(seconds: 0.1))
+            XCTFail("Expected SocketError.timeout")
+        } catch {
+            XCTAssertEqual(error as? SocketError, .makeTaskTimeout(seconds: 0.1))
+        }
     }
 
     func testTaskTimeoutParentReturnsSuccess() async {
@@ -164,7 +167,7 @@ final class TaskTimeoutTests: XCTestCase {
             }
             XCTFail("Expected Error")
         } catch {
-            XCTAssertTrue(error is TimeoutError)
+            XCTAssertEqual(error as? SocketError, .makeTaskTimeout(seconds: 0.05))
         }
     }
 
@@ -196,7 +199,7 @@ final class TaskTimeoutTests: XCTestCase {
             )
             XCTFail("Expected Error")
         } catch {
-            XCTAssertTrue(error is TimeoutError)
+            XCTAssertEqual(error as? SocketError, .makeTaskTimeout(seconds: 0.05))
         }
     }
 


### PR DESCRIPTION
Replaces  the `public struct TimeoutError: Error` with `SocketError.timeout` to consolidate errors enabling a possible update to typed throws for many API in the future.