### PR TITLE
WinSock can't actually support abstract sockets at all...

### DIFF
--- a/FlyingSocks/Sources/Socket+WinSock2.swift
+++ b/FlyingSocks/Sources/Socket+WinSock2.swift
@@ -107,24 +107,6 @@ extension Socket {
         return addr
     }
 
-    static func makeAbstractNamespaceUnix(name: String) -> WinSDK.sockaddr_un {
-        var addr: sockaddr_un = WinSDK.sockaddr_un()
-        addr.sun_family = ADDRESS_FAMILY(AF_UNIX)
-
-        _ = withUnsafeMutableBytes(of: &addr.sun_path) { raw in
-            raw.initializeMemory(as: CChar.self, repeating: 0)
-        }
-
-        let nameBytes = Array(name.utf8.prefix(107))
-        nameBytes.withUnsafeBytes { src in
-            withUnsafeMutableBytes(of: &addr.sun_path) { dst in
-                dst[1 ..< 1 + src.count].copyBytes(from: src)
-            }
-        }
-
-        return addr
-    }
-
     static func fcntl(_ fd: FileDescriptorType, _ cmd: Int32) -> Int32 {
         return -1
     }

--- a/FlyingSocks/Sources/SocketAddress.swift
+++ b/FlyingSocks/Sources/SocketAddress.swift
@@ -111,7 +111,7 @@ public extension SocketAddress where Self == sockaddr_un {
         Socket.makeAddressUnix(path: path)
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(WinSDK)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android)
     static func unix(abstractNamespace: String) -> Self {
         Socket.makeAbstractNamespaceUnix(name: abstractNamespace)
     }

--- a/FlyingSocks/Tests/SocketAddressTests.swift
+++ b/FlyingSocks/Tests/SocketAddressTests.swift
@@ -148,7 +148,7 @@ struct SocketAddressTests {
         )
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(WinSDK)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android)
     @Test
     func unixAbstractNamespace_IsCorrectlyDecodedFromStorage() throws {
         let storage = sockaddr_un
@@ -200,7 +200,7 @@ struct SocketAddressTests {
         )
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(WinSDK)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android)
     @Test
     func unixAbstractNamespace_CheckSize() throws {
         let sun = sockaddr_un.unix(abstractNamespace: "some_great_namespace")


### PR DESCRIPTION
I should have confirmed this before my previous PR... Even though MS claims abstract sockets work, they [actually really really do not work at all](https://github.com/microsoft/WSL/issues/4240).