### PR TITLE
Restore podspec

### DIFF
--- a/FlyingFox.podspec.json
+++ b/FlyingFox.podspec.json
@@ -1,0 +1,29 @@
+{
+  "name": "FlyingFox",
+  "version": "0.24.1",
+  "summary": "Lightweight, HTTP server written in Swift using async/await",
+  "homepage": "https://github.com/swhitty/FlyingFox",
+  "authors": "Simon Whitty",
+  "license": {
+    "type": "MIT",
+    "file": "LICENSE"
+  },
+  "source": {
+    "git": "https://github.com/swhitty/FlyingFox.git",
+    "tag": "0.24.1"
+  },
+  "platforms": {
+    "ios": "13.0",
+    "osx": "10.15",
+    "tvos": "13.0",
+    "watchos": "7.0"
+  },
+  "source_files": "FlyingFox/Sources/**/*.swift",
+  "dependencies": {
+    "FlyingSocks": "~> 0.24.1"
+  },
+  "pod_target_xcconfig": {
+    "OTHER_SWIFT_FLAGS": "-package-name FlyingFox"
+  },
+  "swift_version": "5.10"
+}

--- a/FlyingSocks.podspec.json
+++ b/FlyingSocks.podspec.json
@@ -1,0 +1,26 @@
+{
+  "name": "FlyingSocks",
+  "version": "0.24.1",
+  "summary": "Lightweight, async sockets written in Swift using async/await",
+  "homepage": "https://github.com/swhitty/FlyingFox",
+  "authors": "Simon Whitty",
+  "license": {
+    "type": "MIT",
+    "file": "LICENSE"
+  },
+  "source": {
+    "git": "https://github.com/swhitty/FlyingFox.git",
+    "tag": "0.24.1"
+  },
+  "platforms": {
+    "ios": "13.0",
+    "osx": "10.15",
+    "tvos": "13.0",
+    "watchos": "7.0"
+  },
+  "source_files": "FlyingSocks/Sources/**/*.swift",
+  "pod_target_xcconfig": {
+    "OTHER_SWIFT_FLAGS": "-package-name FlyingFox"
+  },
+  "swift_version": "5.10"
+}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ FlyingFox can be installed by using Swift Package Manager.
 To install using Swift Package Manager, add this to the `dependencies:` section in your Package.swift file:
 
 ```swift
-.package(url: "https://github.com/swhitty/FlyingFox.git", .upToNextMajor(from: "0.24.0"))
+.package(url: "https://github.com/swhitty/FlyingFox.git", .upToNextMajor(from: "0.24.1"))
 ```
 
 # Usage


### PR DESCRIPTION
Support for Cocoapods was removed in the [0.17.0 release](https://github.com/swhitty/FlyingFox/releases/tag/0.17.0) due to incompatibility with [SE-0386 Package access modifier](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0386-package-access-modifier.md) but there is a workaround so I can restore the podspec.

This has now been tagged and published;

```
--------------------------------------------------------------------------------
 🎉  Congrats

 🚀  FlyingFox (0.24.1) successfully published
 📅  July 3rd, 19:49
 🌎  https://cocoapods.org/pods/FlyingFox
 👍  Tell your friends!
--------------------------------------------------------------------------------
```