### PR TITLE
Swift 6.2 SendableMetatype

### DIFF
--- a/FlyingFox/Sources/WebSocket/AsyncStream+WSFrame.swift
+++ b/FlyingFox/Sources/WebSocket/AsyncStream+WSFrame.swift
@@ -48,7 +48,11 @@ extension AsyncThrowingStream<WSFrame, any Error> {
 
 extension AsyncStream<WSFrame> {
 
-    static func protocolFrames<S: AsyncSequence>(from frames: S) -> Self where S.Element == WSFrame {
+#if compiler(<6.2)
+    typealias SendableMetatype = Any
+#endif
+
+    static func protocolFrames<S: AsyncSequence & SendableMetatype>(from frames: S) -> Self where S.Element == WSFrame {
         let iterator = Iterator(from: frames)
         return AsyncStream<WSFrame> {
             do {

--- a/FlyingSocks/Sources/SocketPool.swift
+++ b/FlyingSocks/Sources/SocketPool.swift
@@ -32,6 +32,17 @@
 import Dispatch
 import Foundation
 
+#if compiler(>=6.2)
+public protocol EventQueue: SendableMetatype {
+    mutating func open() throws
+    mutating func stop() throws
+    mutating func close() throws
+
+    mutating func addEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws
+    mutating func removeEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws
+    func getNotifications() throws -> [EventNotification]
+}
+#else
 public protocol EventQueue {
     mutating func open() throws
     mutating func stop() throws
@@ -41,6 +52,7 @@ public protocol EventQueue {
     mutating func removeEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws
     func getNotifications() throws -> [EventNotification]
 }
+#endif
 
 public struct EventNotification: Equatable, Sendable {
     public var file: Socket.FileDescriptor


### PR DESCRIPTION
Addresses Swift 6.2 warnings by conditionally conforming to `SendableMetatype` where required 