### PR TITLE
handleMatchedRequest

### DIFF
--- a/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
@@ -136,6 +136,26 @@ public extension RoutedHTTPHandler {
     }
 }
 
+#if compiler(>=6.0)
+public extension RoutedHTTPHandler {
+
+    static func handleMatchedRequest(
+        isolation: isolated (any Actor)? = #isolation,
+        _ request: HTTPRequest,
+        to route: HTTPRoute,
+        handler: (HTTPRequest) async throws -> HTTPResponse
+    ) async throws -> HTTPResponse? {
+        if await route ~= request {
+            return try await HTTPRequest.$matchedRoute.withValue(route) {
+                _ = isolation
+                return try await handler(request)
+            }
+        }
+        return nil
+    }
+}
+#endif
+
 extension RoutedHTTPHandler: RangeReplaceableCollection {
     public typealias Index = Array<Element>.Index
     public typealias Element = (route: HTTPRoute, handler: any HTTPHandler)


### PR DESCRIPTION
https://github.com/swhitty/FlyingFox/pull/94 added support for "route parameters" within requests handled via `RoutedHTTPHandler`.

Requests handled manually could not use these route parameters because `HTTPRequest.matchedRoute` is internal only.  This PR adds a helper method `RoutedHTTPHandler.handleMatchedRequest()` that handles a request if the route matches, ensuring `HTTPRequest.matchedRoute` is set for the handler;