### PR TITLE
Multiple HTTPHeaders

### DIFF
--- a/FlyingFox/Sources/HTTPEncoder.swift
+++ b/FlyingFox/Sources/HTTPEncoder.swift
@@ -46,8 +46,19 @@ struct HTTPEncoder {
             httpHeaders.addValue(encoding, for: .transferEncoding)
         }
 
-        let headers = httpHeaders.map { "\($0.key.rawValue): \($0.value)" }
+        var headers = [String]()
 
+        for header in httpHeaders.storage.keys.sorted(by: { $0.rawValue < $1.rawValue }) {
+            let values = httpHeaders.storage[header]!
+            if HTTPHeaders.canCombineValues(for: header) {
+                let joinedValues = values.joined(separator: ", ")
+                headers.append("\(header.rawValue): \(joinedValues)")
+            } else {
+                headers.append(
+                    contentsOf: values.map { "\(header.rawValue): \($0)" }
+                )
+            }
+        }
         return [status] + headers + ["\r\n"]
     }
 

--- a/FlyingFox/Sources/HTTPHeader.swift
+++ b/FlyingFox/Sources/HTTPHeader.swift
@@ -52,37 +52,23 @@ public struct HTTPHeader: Sendable, RawRepresentable, Hashable {
 public extension HTTPHeader {
     static let acceptRanges        = HTTPHeader("Accept-Ranges")
     static let authorization       = HTTPHeader("Authorization")
+    static let cookie              = HTTPHeader("Cookie")
     static let connection          = HTTPHeader("Connection")
     static let contentDisposition  = HTTPHeader("Content-Disposition")
     static let contentEncoding     = HTTPHeader("Content-Encoding")
     static let contentLength       = HTTPHeader("Content-Length")
     static let contentRange        = HTTPHeader("Content-Range")
     static let contentType         = HTTPHeader("Content-Type")
+    static let date                = HTTPHeader("Date")
+    static let eTag                = HTTPHeader("ETag")
     static let host                = HTTPHeader("Host")
     static let location            = HTTPHeader("Location")
     static let range               = HTTPHeader("Range")
+    static let setCookie           = HTTPHeader("Set-Cookie")
     static let transferEncoding    = HTTPHeader("Transfer-Encoding")
     static let upgrade             = HTTPHeader("Upgrade")
     static let webSocketAccept     = HTTPHeader("Sec-WebSocket-Accept")
     static let webSocketKey        = HTTPHeader("Sec-WebSocket-Key")
     static let webSocketVersion    = HTTPHeader("Sec-WebSocket-Version")
     static let xForwardedFor       = HTTPHeader("X-Forwarded-For")
-}
-
-public extension [HTTPHeader: String] {
-
-    func values(for header: HTTPHeader) -> [String] {
-        let value = self[header] ?? ""
-        return value
-            .split(separator: ",", omittingEmptySubsequences: true)
-            .map { String($0.trimmingCharacters(in: .whitespaces)) }
-    }
-
-    mutating func setValues(_ values: [String], for header: HTTPHeader) {
-        self[header] = values.joined(separator: ", ")
-    }
-
-    mutating func addValue(_ value: String, for header: HTTPHeader) {
-        setValues(values(for: header) + [value], for: header)
-    }
 }

--- a/FlyingFox/Sources/HTTPHeaders.swift
+++ b/FlyingFox/Sources/HTTPHeaders.swift
@@ -1,0 +1,116 @@
+//
+//  HTTPHeaders.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 13/09/2025.
+//  Copyright © 2025 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+public struct HTTPHeaders: Hashable, Sendable, Sequence, ExpressibleByDictionaryLiteral {
+    var storage: [HTTPHeader: [String]] = [:]
+
+    public init() { }
+
+    public init(_ headers: [HTTPHeader: String]) {
+        self.storage = headers.mapValues { [$0] }
+    }
+
+    public init(dictionaryLiteral elements: (HTTPHeader, String)...) {
+        for (header, value) in elements {
+            if HTTPHeaders.canCombineValues(for: header) {
+                let values = value
+                    .split(separator: ",", omittingEmptySubsequences: true)
+                    .map { String($0.trimmingCharacters(in: .whitespaces)) }
+                storage[header, default: []].append(contentsOf: values)
+            } else {
+                storage[header, default: []].append(value)
+            }
+        }
+    }
+
+    public subscript(header: HTTPHeader) -> String? {
+        get {
+            guard let values = storage[header] else { return nil }
+            if HTTPHeaders.canCombineValues(for: header) {
+                return values.joined(separator: ", ")
+            } else {
+                return values.first
+            }
+        }
+        set {
+            if let newValue {
+                if storage[header] != nil {
+                    storage[header]?[0] = newValue
+                } else {
+                    storage[header] = [newValue]
+                }
+            } else {
+                storage.removeValue(forKey: header)
+            }
+        }
+    }
+
+    public var keys: some Collection<HTTPHeader> {
+        storage.keys
+    }
+
+    public var values: some Collection<[String]> {
+        storage.values
+    }
+
+    public func values(for header: HTTPHeader) -> [String] {
+        storage[header] ?? []
+    }
+
+    public mutating func addValue(_ value: String, for header: HTTPHeader) {
+        storage[header, default: []].append(value)
+    }
+
+    public mutating func setValues(_ values: [String], for header: HTTPHeader) {
+        storage[header] = values
+    }
+
+    public mutating func removeValue(_ header: HTTPHeader) {
+        storage.removeValue(forKey: header)
+    }
+
+    public func makeIterator() -> some IteratorProtocol<(key: HTTPHeader, value: String)> {
+        storage.lazy
+            .flatMap { (key, values) in values.lazy.map { (key, $0) } }
+            .makeIterator()
+    }
+}
+
+package extension HTTPHeaders {
+
+    private static let singleValueHeaders: Set<HTTPHeader> = [
+        .cookie, .setCookie, .date, .eTag, .contentLength, .contentType, .authorization, .host
+    ]
+
+    static func canCombineValues(for header: HTTPHeader) -> Bool {
+        !singleValueHeaders.contains(header)
+    }
+}

--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -36,7 +36,7 @@ public struct HTTPRequest: Sendable {
     public var version: HTTPVersion
     public var path: String
     public var query: [QueryItem]
-    public var headers: [HTTPHeader: String]
+    public var headers: HTTPHeaders
     public var bodySequence: HTTPBodySequence
     public var remoteAddress: Address?
 
@@ -62,7 +62,7 @@ public struct HTTPRequest: Sendable {
                 version: HTTPVersion,
                 path: String,
                 query: [QueryItem],
-                headers: [HTTPHeader: String],
+                headers: HTTPHeaders,
                 body: HTTPBodySequence,
                 remoteAddress: Address? = nil) {
         self.method = method
@@ -84,9 +84,30 @@ public struct HTTPRequest: Sendable {
         self.version = version
         self.path = path
         self.query = query
-        self.headers = headers
+        self.headers = HTTPHeaders(headers)
         self.bodySequence = HTTPBodySequence(data: body)
         self.remoteAddress = nil
+    }
+}
+
+@available(*, deprecated, message: "Use ``HTTPHeaders`` instead of [HTTPHeader: String]")
+public extension HTTPRequest {
+
+    init(method: HTTPMethod,
+         version: HTTPVersion,
+         path: String,
+         query: [QueryItem],
+         headers: [HTTPHeader: String],
+         body: HTTPBodySequence
+    ) {
+        self.init(
+            method: method,
+            version: version,
+            path: path,
+            query: query,
+            headers: HTTPHeaders(headers),
+            body: body
+        )
     }
 }
 

--- a/FlyingFox/Sources/HTTPResponse.swift
+++ b/FlyingFox/Sources/HTTPResponse.swift
@@ -34,7 +34,7 @@ import Foundation
 public struct HTTPResponse: Sendable {
     public var version: HTTPVersion
     public var statusCode: HTTPStatusCode
-    public var headers: [HTTPHeader: String]
+    public var headers: HTTPHeaders
     public var payload: Payload
 
     public enum Payload: @unchecked Sendable {
@@ -65,7 +65,7 @@ public struct HTTPResponse: Sendable {
 
     public init(version: HTTPVersion = .http11,
                 statusCode: HTTPStatusCode,
-                headers: [HTTPHeader: String] = [:],
+                headers: HTTPHeaders = [:],
                 body: Data = Data()) {
         self.version = version
         self.statusCode = statusCode
@@ -75,7 +75,7 @@ public struct HTTPResponse: Sendable {
 
     public init(version: HTTPVersion = .http11,
                 statusCode: HTTPStatusCode,
-                headers: [HTTPHeader: String] = [:],
+                headers: HTTPHeaders = [:],
                 body: HTTPBodySequence) {
         self.version = version
         self.statusCode = statusCode
@@ -83,12 +83,48 @@ public struct HTTPResponse: Sendable {
         self.payload = .httpBody(body)
     }
 
-    public init(headers: [HTTPHeader: String] = [:],
+    public init(headers: HTTPHeaders = [:],
                 webSocket handler: some WSHandler) {
         self.version = .http11
         self.statusCode = .switchingProtocols
         self.headers = headers
         self.payload = .webSocket(handler)
+    }
+}
+
+@available(*, deprecated, message: "Use ``HTTPHeaders`` instead of [HTTPHeader: String]")
+public extension HTTPResponse {
+
+    init(
+        version: HTTPVersion = .http11,
+        statusCode: HTTPStatusCode,
+        headers: [HTTPHeader: String],
+        body: Data = Data()
+    ) {
+        self.init(
+            version: version,
+            statusCode: statusCode,
+            headers: HTTPHeaders(headers),
+            body: body
+        )
+    }
+
+    init(
+        version: HTTPVersion = .http11,
+        statusCode: HTTPStatusCode,
+        headers: [HTTPHeader: String],
+        body: HTTPBodySequence
+    ) {
+        self.init(
+            version: version,
+            statusCode: statusCode,
+            headers: HTTPHeaders(headers),
+            body: body
+        )
+    }
+
+    init(headers: [HTTPHeader: String], webSocket handler: some WSHandler) {
+        self.init(headers: HTTPHeaders(headers), webSocket: handler)
     }
 }
 

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -259,7 +259,7 @@ private extension HTTPRoute {
         return true
     }
 
-    func patternMatch(headers request: [HTTPHeader: String]) -> Bool {
+    func patternMatch(headers request: HTTPHeaders) -> Bool {
         return headers.allSatisfy { header, value in
             value ~= request.values(for: header)
         }

--- a/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
@@ -153,7 +153,7 @@ public struct FileHTTPHandler: HTTPHandler {
         }
     }
 
-    static func makePartialRange(for headers: [HTTPHeader: String], fileSize: Int) -> ClosedRange<Int>? {
+    static func makePartialRange(for headers: HTTPHeaders, fileSize: Int) -> ClosedRange<Int>? {
         guard let headerValue = headers[.range] else { return nil }
         let scanner = Scanner(string: headerValue)
         guard scanner.scanString("bytes") != nil,

--- a/FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift
@@ -77,7 +77,7 @@ public struct WebSocketHTTPHandler: HTTPHandler, Sendable {
     /// - Parameter headers: The headers of the request to verify.
     /// - Returns: The request's key.
     /// - Throws: An ``WSInvalidHandshakeError`` if the headers are invalid.
-    static func verifyHandshakeRequestHeaders(_ headers: [HTTPHeader: String]) throws -> String {
+    static func verifyHandshakeRequestHeaders(_ headers: HTTPHeaders) throws -> String {
         // Verify the headers according to RFC 6455 section 4.2.1 (https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.1)
         // Rule 1 isn't verified because the socket method is specified elsewhere
 

--- a/FlyingFox/Tests/HTTPEncoderTests.swift
+++ b/FlyingFox/Tests/HTTPEncoderTests.swift
@@ -151,6 +151,28 @@ struct HTTPEncoderTests {
     }
 
     @Test
+    func encodesMultipleCookiesHeaders() async throws {
+        var headers = HTTPHeaders()
+        headers.addValue("Fish", for: .setCookie)
+        headers.addValue("Chips", for: .setCookie)
+        let data = try await HTTPEncoder.encodeResponse(
+            .make(headers: headers, body: Data())
+        )
+
+        print(String(data: data, encoding: .utf8)!)
+        #expect(
+            String(data: data, encoding: .utf8) == """
+            HTTP/1.1 200 OK\r
+            Content-Length: 0\r
+            Set-Cookie: Fish\r
+            Set-Cookie: Chips\r
+            \r
+
+            """
+        )
+    }
+
+    @Test
     func encodesRequest() async throws {
         #expect(
             try await HTTPEncoder.encodeRequest(

--- a/FlyingFox/Tests/HTTPHeaderTests.swift
+++ b/FlyingFox/Tests/HTTPHeaderTests.swift
@@ -1,5 +1,5 @@
 //
-//  HTTPHeaderTests.swift
+//  HTTPHeadersTests.swift
 //  FlyingFox
 //
 //  Created by Simon Whitty on 11/07/2024.
@@ -33,12 +33,12 @@
 import Foundation
 import Testing
 
-struct HTTPHeaderTests {
+struct HTTPHeadersTests {
 
     @Test
     func stringValue() {
         // given
-        var headers = [HTTPHeader: String]()
+        var headers = HTTPHeaders()
         headers[.transferEncoding] = "Identity"
 
         #expect(
@@ -62,5 +62,15 @@ struct HTTPHeaderTests {
         #expect(
             headers.values(for: .transferEncoding) == ["Identity", "chunked"]
         )
+    }
+
+    @Test
+    func values() {
+        var headers = HTTPHeaders()
+        headers.addValue("Fish", for: .setCookie)
+        headers.addValue("Chips", for: .setCookie)
+
+        #expect(headers[.setCookie] == "Fish")
+        #expect(headers.values(for: .setCookie) == ["Fish", "Chips"])
     }
 }

--- a/FlyingFox/Tests/HTTPRequest+Mock.swift
+++ b/FlyingFox/Tests/HTTPRequest+Mock.swift
@@ -37,7 +37,7 @@ extension HTTPRequest {
                      version: HTTPVersion = .http11,
                      path: String = "/",
                      query: [QueryItem] = [],
-                     headers: [HTTPHeader: String] = [:],
+                     headers: HTTPHeaders = [:],
                      body: Data = Data(),
                      remoteAddress: Address? = nil) -> Self {
         HTTPRequest(method: method,
@@ -49,7 +49,7 @@ extension HTTPRequest {
                     remoteAddress: remoteAddress)
     }
 
-    static func make(method: HTTPMethod = .GET, _ url: String, headers: [HTTPHeader: String] = [:]) -> Self {
+    static func make(method: HTTPMethod = .GET, _ url: String, headers: HTTPHeaders = [:]) -> Self {
         let (path, query) = HTTPDecoder.make().readComponents(from: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         return HTTPRequest.make(
             method: method,

--- a/FlyingFox/Tests/HTTPResponse+Mock.swift
+++ b/FlyingFox/Tests/HTTPResponse+Mock.swift
@@ -37,7 +37,7 @@ extension HTTPResponse {
 
     static func make(version: HTTPVersion = .http11,
                      statusCode: HTTPStatusCode  = .ok,
-                     headers: [HTTPHeader: String] = [:],
+                     headers: HTTPHeaders = [:],
                      body: Data = Data()) -> Self {
         HTTPResponse(version: version,
                      statusCode: statusCode,
@@ -47,7 +47,7 @@ extension HTTPResponse {
 
     static func makeChunked(version: HTTPVersion = .http11,
                             statusCode: HTTPStatusCode  = .ok,
-                            headers: [HTTPHeader: String] = [:],
+                            headers: HTTPHeaders = [:],
                             body: Data = Data(),
                             chunkSize: Int = 5) -> Self {
         let consuming = ConsumingAsyncSequence(body)
@@ -61,7 +61,7 @@ extension HTTPResponse {
 
     static func make(version: HTTPVersion = .http11,
                      statusCode: HTTPStatusCode  = .ok,
-                     headers: [HTTPHeader: String] = [:],
+                     headers: HTTPHeaders = [:],
                      body: HTTPBodySequence) -> Self {
         HTTPResponse(version: version,
                      statusCode: statusCode,

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -359,31 +359,26 @@ struct HTTPRouteTests {
 
     @Test
     func header_MatchesRoute() async {
-        let route = HTTPRoute("GET /mock", headers: [.contentType: "json"])
+        let route = HTTPRoute("GET /mock", headers: [.contentEncoding: "json"])
+
 
         #expect(
             await route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
-                                      headers: [.contentType: "json"])
+                                      headers: [.contentEncoding: "xml, json"])
         )
 
         #expect(
             await route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
-                                      headers: [.contentType: "xml, json"])
-        )
-
-        #expect(
-            await route ~= HTTPRequest.make(method: .GET,
-                                      path: "/mock",
-                                      headers: [.contentEncoding: "xml",
-                                                .contentType: "json"])
+                                      headers: [.contentType: "xml",
+                                                .contentEncoding: "json"])
         )
 
         #expect(
             !(await route ~= HTTPRequest.make(method: .GET,
                                               path: "/mock",
-                                              headers: [.contentType: "xml"]))
+                                              headers: [.contentEncoding: "xml"]))
         )
     }
 

--- a/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
@@ -330,7 +330,7 @@ struct HTTPHandlerTests {
 }
 
 private extension FileHTTPHandler {
-    static func makePartialRange(for headers: [HTTPHeader: String]) -> ClosedRange<Int>? {
+    static func makePartialRange(for headers: HTTPHeaders) -> ClosedRange<Int>? {
         makePartialRange(for: headers, fileSize: 10000)
     }
 }

--- a/FlyingFox/Tests/Handlers/WebSocketHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/WebSocketHTTPHandlerTests.swift
@@ -69,7 +69,7 @@ struct WebSocketHTTPHandlerTests {
 
         let handler = WebSocketHTTPHandler.make()
 
-        let headers: [HTTPHeader: String] = [
+        let headers: HTTPHeaders = [
             .host: "localhost",
             .connection: "Upgrade",
             .upgrade: "websocket",
@@ -179,14 +179,14 @@ struct WebSocketHTTPHandlerTests {
     }
 }
 
-private extension Dictionary where Key == HTTPHeader, Value == String {
+private extension HTTPHeaders {
 
     static func makeWSHeaders(host: String? = "localhost",
                               connection: String? = "Upgrade",
                               upgrade: String? = "websocket",
                               webSocketKey: String? = "ABCDEFGHIJKLMNOP",
                               webSocketVersion: String? = "13") -> Self {
-        var headers = [HTTPHeader: String] ()
+        var headers = HTTPHeaders()
         headers[.host] = host
         headers[.connection] = connection
         headers[.upgrade] = upgrade

--- a/FlyingFox/XCTests/HTTPHeaderTests.swift
+++ b/FlyingFox/XCTests/HTTPHeaderTests.swift
@@ -37,7 +37,7 @@ final class HTTPHeaderTests: XCTestCase {
 
     func testStringValue() {
         // given
-        var headers = [HTTPHeader: String]()
+        var headers = HTTPHeaders()
         headers[.transferEncoding] = "Identity"
 
         XCTAssertEqual(

--- a/FlyingFox/XCTests/HTTPRequest+Mock.swift
+++ b/FlyingFox/XCTests/HTTPRequest+Mock.swift
@@ -37,7 +37,7 @@ extension HTTPRequest {
                      version: HTTPVersion = .http11,
                      path: String = "/",
                      query: [QueryItem] = [],
-                     headers: [HTTPHeader: String] = [:],
+                     headers: HTTPHeaders = [:],
                      body: Data = Data(),
                      remoteAddress: Address? = nil) -> Self {
         HTTPRequest(method: method,
@@ -49,7 +49,7 @@ extension HTTPRequest {
                     remoteAddress: remoteAddress)
     }
 
-    static func make(method: HTTPMethod = .GET, _ url: String, headers: [HTTPHeader: String] = [:]) -> Self {
+    static func make(method: HTTPMethod = .GET, _ url: String, headers: HTTPHeaders = [:]) -> Self {
         let (path, query) = HTTPDecoder.make().readComponents(from: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         return HTTPRequest.make(
             method: method,
@@ -57,6 +57,12 @@ extension HTTPRequest {
             query: query,
             headers: headers
         )
+    }
+
+    var bodyString: String {
+        get async throws {
+            try await String(decoding: bodyData, as: UTF8.self)
+        }
     }
 }
 

--- a/FlyingFox/XCTests/HTTPRouteTests.swift
+++ b/FlyingFox/XCTests/HTTPRouteTests.swift
@@ -328,31 +328,31 @@ final class HTTPRouteTests: XCTestCase {
     }
 
     func testHeader_MatchesRoute() async {
-        let route = HTTPRoute("GET /mock", headers: [.contentType: "json"])
+        let route = HTTPRoute("GET /mock", headers: [.contentEncoding: "json"])
 
         await AsyncAssertTrue(
             await route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
-                                      headers: [.contentType: "json"])
+                                      headers: [.contentEncoding: "json"])
         )
 
         await AsyncAssertTrue(
             await route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
-                                      headers: [.contentType: "xml, json"])
+                                      headers: [.contentEncoding: "xml, json"])
         )
 
         await AsyncAssertTrue(
             await route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
-                                      headers: [.contentEncoding: "xml",
-                                                .contentType: "json"])
+                                      headers: [.contentEncoding: "json",
+                                                .contentType: "xml"])
         )
 
         await AsyncAssertFalse(
             await route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
-                                      headers: [.contentType: "xml"])
+                                      headers: [.contentEncoding: "xml"])
         )
     }
 

--- a/FlyingFox/XCTests/Handlers/WebSocketHTTPHandlerTests.swift
+++ b/FlyingFox/XCTests/Handlers/WebSocketHTTPHandlerTests.swift
@@ -70,7 +70,7 @@ final class WebSocketHTTPHandlerTests: XCTestCase {
 
         let handler = WebSocketHTTPHandler.make()
 
-        let headers: [HTTPHeader: String] = [
+        let headers: HTTPHeaders = [
             .host: "localhost",
             .connection: "Upgrade",
             .upgrade: "websocket",
@@ -180,14 +180,14 @@ final class WebSocketHTTPHandlerTests: XCTestCase {
     }
 }
 
-private extension Dictionary where Key == HTTPHeader, Value == String {
+private extension HTTPHeaders {
 
     static func makeWSHeaders(host: String? = "localhost",
                               connection: String? = "Upgrade",
                               upgrade: String? = "websocket",
                               webSocketKey: String? = "ABCDEFGHIJKLMNOP",
                               webSocketVersion: String? = "13") -> Self {
-        var headers = [HTTPHeader: String] ()
+        var headers = HTTPHeaders()
         headers[.host] = host
         headers[.connection] = connection
         headers[.upgrade] = upgrade


### PR DESCRIPTION
Replaces dictionary representations of headers  `[HTTPHeader: String]` with a type `HTTPHeaders` which continues to support subscript and dictionary literal API

```swift
let response = HTTPResponse(headers: [.contentEncoding: "xml"])

response.headers[.contentEncoding] // "xml"
```

But also supports appending multiple values which 

```swift
var headers = HTTPHeaders()

headers.addValue("fish" for: .setCookie)
headers.addValue("chips" for: .setCookie)

response.headers.values(for: .setCookie) == [
  (header: .setCookie, value: "fish"),
  (header: .setCookie, value: "chips"),
]
```


It continues to support combining (supported) headers into a comma delimited value

```swift
var headers = HTTPHeaders()

headers.addValue("xml" for: .contentEncoding)
headers.addValue("html" for: .contentEncoding)

response.headers[.contentEncoding] // "xml, html"
```