### PR TITLE
simplify JSONValue

### DIFF
--- a/FlyingFox/Sources/JSON/JSONBodyPattern.swift
+++ b/FlyingFox/Sources/JSON/JSONBodyPattern.swift
@@ -31,14 +31,14 @@
 
 import Foundation
 
-public extension HTTPBodyPattern where Self == JSONValuePattern {
+public extension HTTPBodyPattern where Self == JSONBodyPattern {
 
-    static func jsonValue(where predicate: @escaping @Sendable (JSONValue) throws -> Bool) -> JSONValuePattern {
-        JSONValuePattern(predicate)
+    static func jsonValue(where predicate: @escaping @Sendable (JSONValue) throws -> Bool) -> JSONBodyPattern {
+        JSONBodyPattern(predicate)
     }
 }
 
-public struct JSONValuePattern: HTTPBodyPattern {
+public struct JSONBodyPattern: HTTPBodyPattern {
 
     private let predicate: @Sendable (JSONValue) throws -> Bool
 

--- a/FlyingFox/Tests/JSON/JSONBodyPatternTests.swift
+++ b/FlyingFox/Tests/JSON/JSONBodyPatternTests.swift
@@ -1,5 +1,5 @@
 //
-//  JSONValuePatternTests.swift
+//  JSONBodyPatternTests.swift
 //  FlyingFox
 //
 //  Created by Simon Whitty on 15/08/2024.
@@ -33,12 +33,12 @@ import FlyingFox
 import Foundation
 import Testing
 
-struct JSONValuePatternTests {
+struct JSONBodyPatternTests {
 
     @Test
     func pattern_MatchesJSONPath() async throws {
         // given
-        let pattern = JSONValuePattern { try $0.getValue(for: "$.name") == .string("fish") }
+        let pattern = JSONBodyPattern { try $0.getValue(for: "$.name") == "fish" }
 
         // when then
         #expect(pattern.evaluate(json: #"{"name": "fish"}"#))
@@ -53,7 +53,7 @@ struct JSONValuePatternTests {
         // given
         let route = HTTPRoute(
             "POST /fish",
-            jsonBody: { try $0.getValue(for: "$.food") == .string("chips")  }
+            jsonBody: { try $0.getValue(for: "$.food") == "chips"  }
         )
 
         // when
@@ -70,13 +70,12 @@ struct JSONValuePatternTests {
     }
 }
 
-private extension JSONValuePattern {
+private extension JSONBodyPattern {
 
     func evaluate(json: String) -> Bool {
         self.evaluate(Data(json.utf8))
     }
 }
-
 
 private extension HTTPRequest {
     static func make(method: HTTPMethod = .POST,

--- a/FlyingFox/Tests/JSON/JSONPathTests.swift
+++ b/FlyingFox/Tests/JSON/JSONPathTests.swift
@@ -85,16 +85,16 @@ struct JSONPathTests {
         """#)
 
         #expect(
-            try json.getValue(for: "$.owner.age").asNumber() == 7
+            try json.getValue(for: "$.owner.age") == 7
         )
         #expect(
-            try json.getValue(for: "$.owner.isAdmin").asBool()
+            try json.getValue(for: "$.owner.isAdmin") == true
         )
         #expect(
-            try json.getValue(for: "$.users[1].food").asString() == "chips"
+            try json.getValue(for: "$.users[1].food") == "chips"
         )
         #expect(
-            try json.getValue(for: "$.users[2].age").asNumber() == 9
+            try json.getValue(for: "$.users[2].age") == 9
         )
     }
 

--- a/FlyingFox/Tests/JSON/JSONValueTests.swift
+++ b/FlyingFox/Tests/JSON/JSONValueTests.swift
@@ -30,140 +30,96 @@
 //
 
 import FlyingFox
+import Foundation
 import Testing
 
 struct JSONValueTests {
 
     @Test
-    func objects_CanBeUpdated_ToNull() throws {
+    func json_string() throws {
         // given
-        var val = JSONValue.object([:])
+        let val = try JSONValue("fish")
 
-        // when
-        try val.updateValue(parsing: "null")
+        // then
+        #expect(val == "fish")
+        #expect(val != "chips")
+    }
+
+    @Test
+    func json_int() throws {
+        // given
+        let val = try JSONValue(Int(10))
+
+        // then
+        #expect(val == 10)
+        #expect(val != 100)
+    }
+
+    @Test
+    func json_double() throws {
+        // given
+        let val = try JSONValue(10.5)
+
+        // then
+        #expect(val == 10.5)
+        #expect(val != 100.5)
+    }
+
+    @Test
+    func json_bool() throws {
+        // given
+        let val = try JSONValue(true)
+
+        // then
+        #expect(val == true)
+        #expect(val != false)
+    }
+
+    @Test
+    func json_nsnull() throws {
+        // given
+        let val = try JSONValue(NSNull())
 
         // then
         #expect(val == .null)
+        #expect(val != "fish")
     }
 
     @Test
-    func arrays_CanBeUpdated_ToNull() throws {
+    func json_anyNone() throws {
         // given
-        var val = JSONValue.array([])
-
-        // when
-        try val.updateValue(parsing: "null")
+        let val = try JSONValue(String?.none as Any)
 
         // then
         #expect(val == .null)
+        #expect(val != "fish")
     }
 
     @Test
-    func string_CanBeUpdated_ToNull() throws {
+    func json_optionalNone() throws {
         // given
-        var val = JSONValue.string("")
-
-        // when
-        try val.updateValue(parsing: "null")
+        let val = try JSONValue(String?.none)
 
         // then
         #expect(val == .null)
+        #expect(val != "fish")
     }
 
     @Test
-    func number_CanBeUpdated_ToNull() throws {
+    func json_optionalSome() throws {
         // given
-        var val = JSONValue.number(10)
-
-        // when
-        try val.updateValue(parsing: "null")
+        let val = try JSONValue(String?.some("fish"))
 
         // then
-        #expect(val == .null)
+        #expect(val == "fish")
+        #expect(val != .null)
     }
 
     @Test
-    func bool_CanBeUpdated_ToNull() throws {
-        // given
-        var val = JSONValue.boolean(true)
-
-        // when
-        try val.updateValue(parsing: "null")
-
-        // then
-        #expect(val == .null)
-    }
-
-    @Test
-    func null_CanBeUpdated_ToNull() throws {
-        // given
-        var val = JSONValue.null
-
-        // when
-        try val.updateValue(parsing: "null")
-
-        // then
-        #expect(val == .null)
-    }
-
-    @Test
-    func null_CanBeUpdated_ToObject() throws {
-        // given
-        var val = JSONValue.null
-
-        // when
-        try val.updateValue(parsing: "{\"foo\":\"bar\"}")
-
-        // then
-        #expect(val == .object(["foo": .string("bar")]))
-    }
-
-    @Test
-    func null_CanBeUpdated_ToArray() throws {
-        // given
-        var val = JSONValue.null
-
-        // when
-        try val.updateValue(parsing: "[1,2]")
-
-        // then
-        #expect(val == .array([.number(1), .number(2)]))
-    }
-
-    @Test
-    func null_CanBeUpdated_ToNumber() throws {
-        // given
-        var val = JSONValue.null
-
-        // when
-        try val.updateValue(parsing: "1")
-
-        // then
-        #expect(val == .number(1))
-    }
-
-    @Test
-    func null_CanBeUpdated_ToBool() throws {
-        // given
-        var val = JSONValue.null
-
-        // when
-        try val.updateValue(parsing: "true")
-
-        // then
-        #expect(val == .boolean(true))
-    }
-
-    @Test
-    func null_CanBeUpdated_ToString() throws {
-        // given
-        var val = JSONValue.null
-
-        // when
-        try val.updateValue(parsing: "foo")
-
-        // then
-        #expect(val == .string("foo"))
+    func json_invalid() {
+        #expect(throws: (any Error).self) {
+            try JSONValue(HTTPRequest.make())
+        }
     }
 
     #if canImport(Darwin)


### PR DESCRIPTION
Simplifies public interface of JSONValue removing redundant methods.

renames `JSONValuePattern` to `JSONBodyPattern` as it is a HTTPBodyPattern implementation.

adds `==` operator for common comparisons to JSONValue

```swift
JSONValue.string("fish") == "fish"
JSONValue.number(10) == 10
JSONValue.bool(true) == true
```

allows for routes to use:

```swift
 let route = HTTPRoute(
   "POST /fish",
   jsonBody: { try $0.getValue(for: "$.food") == "chips" }
)
```