### PR TITLE
Add HTTPRequest.Target

### DIFF
--- a/FlyingFox/Sources/HTTPEncoder.swift
+++ b/FlyingFox/Sources/HTTPEncoder.swift
@@ -117,4 +117,14 @@ struct HTTPEncoder {
 
         return data
     }
+
+    static func makeTarget(path: String, query: [HTTPRequest.QueryItem]) -> HTTPRequest.Target {
+        var comps = URLComponents()
+        comps.path = path
+        comps.queryItems = query.map { .init(name: $0.name, value: $0.value) }
+        return HTTPRequest.Target(
+            path: comps.percentEncodedPath,
+            query: comps.percentEncodedQuery ?? ""
+        )
+    }
 }

--- a/FlyingFox/Sources/HTTPRequest+Target.swift
+++ b/FlyingFox/Sources/HTTPRequest+Target.swift
@@ -1,0 +1,71 @@
+//
+//  HTTPRequest+Target.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 08/11/2025.
+//  Copyright © 2025 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+public extension HTTPRequest {
+
+    // RFC9112: e.g. /a%2Fb?q=1
+    struct Target: Sendable, Equatable {
+
+        // raw percent encoded path e.g. /fish%20chips
+        private var _path: String
+
+        // raw percent encoded query string e.g. q=fish%26chips&qty=15
+        private var _query: String
+
+        public init(path: String, query: String) {
+            self._path = path
+            self._query = query
+        }
+
+        public func path(percentEncoded: Bool = true) -> String {
+            guard percentEncoded else {
+                return _path.removingPercentEncoding ?? _path
+            }
+            return _path
+        }
+
+        public func query(percentEncoded: Bool = true) -> String {
+            guard percentEncoded else {
+                return _query.removingPercentEncoding ?? _query
+            }
+            return _query
+        }
+
+        public var rawValue: String {
+            guard !_query.isEmpty else {
+                return _path
+            }
+            return "\(_path)?\(_query)"
+        }
+    }
+}

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -383,9 +383,3 @@ public extension Array where Element == HTTPRoute.Parameter {
         }
     }
 }
-
-private extension HTTPDecoder {
-    init() {
-        self.init(sharedRequestBufferSize: 128, sharedRequestReplaySize: 1024)
-    }
-}

--- a/FlyingFox/Tests/HTTPConnectionTests.swift
+++ b/FlyingFox/Tests/HTTPConnectionTests.swift
@@ -55,6 +55,7 @@ struct HTTPConnectionTests {
         )
 
         let request = try await connection.requests.first()
+        print(request)
         #expect(
             await request == .make(
                 method: .GET,

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -212,7 +212,7 @@ struct HTTPDecoderTests {
 
     @Test
     func invalidPathDecodes() {
-        let comps = HTTPDecoder.make().makeComponents(from: nil)
+        let comps = HTTPDecoder.make().readComponents(from: "")
         #expect(comps.path == "")
         #expect(comps.query == [])
     }
@@ -243,11 +243,8 @@ struct HTTPDecoderTests {
 
     @Test
     func emptyQueryItem_Decodes() {
-        var urlComps = URLComponents()
-        urlComps.queryItems = [.init(name: "name", value: nil)]
-
         #expect(
-            HTTPDecoder.make().makeComponents(from: urlComps).query == [
+            HTTPDecoder.make().readComponents(from: "/?name=").query == [
                 .init(name: "name", value: "")
             ]
         )

--- a/FlyingFox/Tests/HTTPRequest+Mock.swift
+++ b/FlyingFox/Tests/HTTPRequest+Mock.swift
@@ -33,20 +33,42 @@
 import Foundation
 
 extension HTTPRequest {
-    static func make(method: HTTPMethod = .GET,
-                     version: HTTPVersion = .http11,
-                     path: String = "/",
-                     query: [QueryItem] = [],
-                     headers: HTTPHeaders = [:],
-                     body: Data = Data(),
-                     remoteAddress: Address? = nil) -> Self {
-        HTTPRequest(method: method,
-                    version: version,
-                    path: path,
-                    query: query,
-                    headers: headers,
-                    body:  HTTPBodySequence(data: body),
-                    remoteAddress: remoteAddress)
+    static func make(
+        method: HTTPMethod = .GET,
+        version: HTTPVersion = .http11,
+        target: String = "/",
+        headers: HTTPHeaders = [:],
+        body: Data = Data(),
+        remoteAddress: Address? = nil
+    ) -> Self {
+        HTTPRequest(
+            method: method,
+            version: version,
+            target: HTTPDecoder().makeTarget(from: target),
+            headers: headers,
+            body:  HTTPBodySequence(data: body),
+            remoteAddress: remoteAddress
+        )
+    }
+
+    static func make(
+        method: HTTPMethod = .GET,
+        version: HTTPVersion = .http11,
+        path: String = "/",
+        query: [QueryItem] = [],
+        headers: HTTPHeaders = [:],
+        body: Data = Data(),
+        remoteAddress: Address? = nil
+    ) -> Self {
+        HTTPRequest(
+            method: method,
+            version: version,
+            path: path,
+            query: query,
+            headers: headers,
+            body:  HTTPBodySequence(data: body),
+            remoteAddress: remoteAddress
+        )
     }
 
     static func make(method: HTTPMethod = .GET, _ url: String, headers: HTTPHeaders = [:]) -> Self {

--- a/FlyingFox/Tests/HTTPRequestTests.swift
+++ b/FlyingFox/Tests/HTTPRequestTests.swift
@@ -53,4 +53,39 @@ struct HTTPRequestTests {
             try await request.bodyData == Data([0x05, 0x06])
         )
     }
+
+    @Test
+    func targetIsCreated() {
+        // when
+        let request = HTTPRequest.make(path: "/meal plan/order", query: [
+            .init(name: "food", value: "fish & chips"),
+            .init(name: "qty", value: "15")
+        ])
+
+        // then
+        #expect(request.target.rawValue == "/meal%20plan/order?food=fish%20%26%20chips&qty=15")
+        #expect(request.target.path() == "/meal%20plan/order")
+        #expect(request.target.path(percentEncoded: false) == "/meal plan/order")
+        #expect(request.target.query() == "food=fish%20%26%20chips&qty=15")
+        #expect(request.target.query(percentEncoded: false) == "food=fish & chips&qty=15")
+    }
+
+    @Test
+    func pathIsCreated() {
+        // when
+        let request = HTTPRequest.make(
+            target: "/meal%20plan/order?food=fish%20%26%20chips&qty=15"
+        )
+
+        // then
+        #expect(request.path == "/meal plan/order")
+        #expect(request.query == [
+            .init(name: "food", value: "fish & chips"),
+            .init(name: "qty", value: "15")
+        ])
+        #expect(request.target.path() == "/meal%20plan/order")
+        #expect(request.target.path(percentEncoded: false) == "/meal plan/order")
+        #expect(request.target.query() == "food=fish%20%26%20chips&qty=15")
+        #expect(request.target.query(percentEncoded: false) == "food=fish & chips&qty=15")
+    }
 }


### PR DESCRIPTION
Adds `HTTPRequest.target` to preserve the raw path and query string from the request as per [RFC9112](https://www.rfc-editor.org/rfc/rfc9112.html#name-request-target) allowing access to either percent encoded or the original raw path / query string.

resolves #175 


A request like so;

```
GET /hello%20world?fish=%2Fchips HTTP/1.1
```

Produces the following `HTTPRequest`:

```swift
request.path == "/hello world"
request.target.path() == "/hello%20world"
request.target.path(percentEncoded: false) == "/hello world"

request.query == [QueryItem(name: "fish", value="/chips"]
request.target.query() == "fish=%2Fchips"
request.target.query(percentEncoded: false) == "fish=/chips"
```