### PR TITLE
epoll() candidate fixes

### DIFF
--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -629,7 +629,7 @@ package extension Socket {
     }
 }
 
-fileprivate func errnoSignalsDisconnected() -> Bool {
+func errnoSignalsDisconnected() -> Bool {
     #if canImport(WinSDK)
     return errno == WSAENOTSOCK || errno == WSAENOTCONN || errno == WSAECONNRESET
     #else


### PR DESCRIPTION
Possible fix for #186, but note this was done by Claude and I have not reviewed it myself (indeed I don't really know enough about `epoll(7)` to do so).