### PR TITLE
Fix high CPU usage on Linux due to epoll busy-loop

### DIFF
--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -517,7 +517,11 @@ extension Socket.Event: CustomStringConvertible {
 public extension Socket.Events {
     static let read: Self = [.read]
     static let write: Self = [.write]
+    #if canImport(CSystemLinux)
+    static let connection: Self = [.read]
+    #else
     static let connection: Self = [.read, .write]
+    #endif
 }
 
 public protocol SocketOption {

--- a/FlyingSocks/Sources/SocketPool+ePoll.swift
+++ b/FlyingSocks/Sources/SocketPool+ePoll.swift
@@ -33,28 +33,35 @@
 import CSystemLinux
 
 public extension AsyncSocketPool where Self == SocketPool<ePoll> {
-    static func ePoll(maxEvents limit: Int = 20, logger: some Logging = .disabled) -> SocketPool<ePoll> {
-        .init(maxEvents: limit, logger: logger)
+    static func ePoll(triggering: ePoll.TriggerMode = .edge, maxEvents limit: Int = 20, logger: some Logging = .disabled) -> SocketPool<ePoll> {
+        .init(triggering: triggering, maxEvents: limit, logger: logger)
     }
 
-    private init(maxEvents limit: Int, logger: some Logging = .disabled) {
-        self.init(queue: FlyingSocks.ePoll(maxEvents: limit, logger: logger), logger: logger)
+    private init(triggering: ePoll.TriggerMode, maxEvents limit: Int, logger: some Logging = .disabled) {
+        self.init(queue: FlyingSocks.ePoll(triggering: triggering, maxEvents: limit, logger: logger), logger: logger)
     }
 }
 
 public struct ePoll: EventQueue {
 
+    public enum TriggerMode: Sendable {
+        case edge
+        case level
+    }
+
     private(set) var file: Socket.FileDescriptor
     private(set) var canary: Socket.FileDescriptor
     private(set) var existing: [Socket.FileDescriptor: Socket.Events]
     private let eventsLimit: Int
+    private let triggerMode: TriggerMode
     private let logger: any Logging
 
-    public init(maxEvents limit: Int, logger: some Logging = .disabled) {
+    public init(triggering: TriggerMode = .edge, maxEvents limit: Int, logger: some Logging = .disabled) {
         self.file = .invalid
         self.canary = .invalid
         self.existing = [:]
         self.eventsLimit = limit
+        self.triggerMode = triggering
         self.logger = logger
     }
 
@@ -105,8 +112,9 @@ public struct ePoll: EventQueue {
     }
 
     mutating func setEvents(_ events: Socket.Events, for socket: Socket.FileDescriptor) throws {
+        guard existing[socket] != events else { return }
         var event = CSystemLinux.epoll_event()
-        event.events = events.epollEvents.rawValue
+        event.events = events.epollEvents(triggerMode: triggerMode).rawValue
         event.data.fd = socket.rawValue
 
         if existing[socket] != nil {
@@ -241,8 +249,12 @@ private struct EPOLLEvents: OptionSet, Hashable {
 
 private extension Socket.Events {
 
-    var epollEvents: EPOLLEvents {
-        reduce(EPOLLEvents()) { [$0, $1.epollEvent] }
+    func epollEvents(triggerMode: ePoll.TriggerMode) -> EPOLLEvents {
+        var events = reduce(EPOLLEvents()) { [$0, $1.epollEvent] }
+        if triggerMode == .edge {
+            events.insert(.edgeTriggered)
+        }
+        return events
     }
 
     static func make(from pollevents: EPOLLEvents) -> Socket.Events {

--- a/FlyingSocks/Tests/SocketPool+PollTests.swift
+++ b/FlyingSocks/Tests/SocketPool+PollTests.swift
@@ -104,7 +104,11 @@ struct PollTests {
         let entry = Poll.Entry(file: .init(rawValue: 30), events: .connection)
 
         #expect(entry.pollfd.fd == 30)
+        #if canImport(CSystemLinux)
+        #expect(entry.pollfd.events == Int16(POLLIN))
+        #else
         #expect(entry.pollfd.events == Int16(POLLOUT | POLLIN))
+        #endif
         #expect(entry.pollfd.revents == 0)
     }
 
@@ -162,7 +166,7 @@ struct PollTests {
                 revents: POLLHUP
             )) == EventNotification(
                 file: .init(rawValue: 10),
-                events: .connection,
+                events: [.read, .write],
                 errors: [.endOfFile]
             )
         )

--- a/FlyingSocks/Tests/SocketPoolTests.swift
+++ b/FlyingSocks/Tests/SocketPoolTests.swift
@@ -242,7 +242,7 @@ struct SocketPoolTests {
             Set(waiting.continuationIDs(for: .validMock, events: .write)) == [cnWrite.id]
         )
         #expect(
-            Set(waiting.continuationIDs(for: .validMock, events: .connection)) == [cnRead1.id, cnRead.id, cnWrite.id]
+            Set(waiting.continuationIDs(for: .validMock, events: [.read, .write])) == [cnRead1.id, cnRead.id, cnWrite.id]
         )
         #expect(
             Set(waiting.continuationIDs(for: .validMock, events: [])) == []


### PR DESCRIPTION
NB: these fixes were generated by AmpCode. They appear to fix the issue and also do not break tests.

—

Three fixes for 100% CPU spinning when HTTPServer is idle on Linux:

1. Use edge-triggered (EPOLLET) mode for all sockets, not just the canary eventfd. Level-triggered epoll causes epoll_wait() to return immediately when the listening socket is readable, creating a busy loop.

2. Change accept() to wait on .read events only instead of .connection ([.read, .write]). A listening socket is always writable (EPOLLOUT), so registering for write events causes immediate spurious wakeups. accept() only needs readability (a pending connection).

3. Skip redundant epoll_ctl(EPOLL_CTL_MOD) calls when the event mask hasn't changed. EPOLL_CTL_MOD re-arms edge-triggered events and can cause spurious wakeups when the condition is already met.

Fixes: #186