### PR TITLE
Add Cache Control to FileHTTPHandler headers

### DIFF
--- a/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
@@ -130,6 +130,7 @@ public struct FileHTTPHandler: HTTPHandler {
             var headers: HTTPHeaders = [
                 .contentType: contentType,
                 .acceptRanges: "bytes",
+                .cacheControl: cacheControl.getSerializedValue(),
                 .date: HTTPCacheControl.getDateHeaderValue()
             ]
             


### PR DESCRIPTION
I believe this header may have been missed in @nspassov's #194 - Add support for Cache-Control in Directory and File HTTPHandler. 

This updates FileHTTPHander handleRequest() headers to match the  implementation in DirectoryHTTPHandler.
