### PR TITLE
public SocketError.makeFailed()

### DIFF
--- a/FlyingSocks/Sources/SocketError.swift
+++ b/FlyingSocks/Sources/SocketError.swift
@@ -68,7 +68,7 @@ public enum SocketError: LocalizedError, Equatable {
         }
     }
 
-    static func makeFailed(_ type: StaticString) -> Self {
+    public static func makeFailed(_ type: StaticString) -> Self {
         .failed(type: String(describing: type),
                 errno: errno,
                 message: String(cString: strerror(errno)))


### PR DESCRIPTION
make `SocketError.makeFailed(...)` `public` so 3rd party extensions can throw `SocketError`.

As requested in #192 