### PR TITLE
public EventNotification.init

### DIFF
--- a/FlyingSocks/Sources/SocketPool.swift
+++ b/FlyingSocks/Sources/SocketPool.swift
@@ -67,6 +67,12 @@ public struct EventNotification: Equatable, Sendable {
         case endOfFile
         case error
     }
+
+    public init(file: Socket.FileDescriptor, events: Socket.Events, errors: Set<Error>) {
+        self.file = file
+        self.events = events
+        self.errors = errors
+    }
 }
 
 @available(*, unavailable, message: "use .make(maxEvents:)")


### PR DESCRIPTION
make ` EventNotification.init` `public` so 3rd part extensions can init `EventNotitifcation`.

As requested in #189 