### PR TITLE
Fix typo: makeIdentifer -> makeIdentifier

### DIFF
--- a/FlyingFox/Sources/HTTPConnection.swift
+++ b/FlyingFox/Sources/HTTPConnection.swift
@@ -45,7 +45,7 @@ struct HTTPConnection: Sendable {
         self.decoder = decoder
         self.logger = logger
 
-        let (peer, identifier) = HTTPConnection.makeIdentifer(from: socket.socket)
+        let (peer, identifier) = HTTPConnection.makeIdentifier(from: socket.socket)
         self.hostname = identifier
         self.requests = HTTPRequestSequence(bytes: socket.bytes, decoder: decoder, remoteAddress: peer)
     }
@@ -156,19 +156,19 @@ actor HTTPRequestSequence<S: AsyncBufferedSequence & Sendable>: AsyncSequence, A
 
 extension HTTPConnection {
 
-    static func makeIdentifer(from socket: Socket) -> (address: Socket.Address?, identifier: String) {
+    static func makeIdentifier(from socket: Socket) -> (address: Socket.Address?, identifier: String) {
         guard let peer = try? socket.remotePeer() else {
             return (nil, "unknown")
         }
 
         if case .unix = peer, let unixAddress = try? socket.sockname() {
-            return (peer, makeIdentifer(from: unixAddress))
+            return (peer, makeIdentifier(from: unixAddress))
         } else {
-            return (peer, makeIdentifer(from: peer))
+            return (peer, makeIdentifier(from: peer))
         }
     }
 
-    static func makeIdentifer(from peer: Socket.Address) -> String {
+    static func makeIdentifier(from peer: Socket.Address) -> String {
         switch peer {
         case .ip4(let address, port: _):
             return address

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -340,24 +340,24 @@ public extension HTTPServer {
 extension Logging {
 
     func logOpenConnection(_ connection: HTTPConnection) {
-        logInfo("\(connection.identifer) open connection")
+        logInfo("\(connection.identifier) open connection")
     }
 
     func logCloseConnection(_ connection: HTTPConnection) {
-        logInfo("\(connection.identifer) close connection")
+        logInfo("\(connection.identifier) close connection")
     }
 
     func logSwitchProtocol(_ connection: HTTPConnection, to protocol: String) {
-        logInfo("\(connection.identifer) switching protocol to \(`protocol`)")
+        logInfo("\(connection.identifier) switching protocol to \(`protocol`)")
     }
 
     func logRequest(_ request: HTTPRequest, on connection: HTTPConnection) {
         let suffix = request.headers[.range] != nil ? " <ranged>" : ""
-        logInfo("\(connection.identifer) request: \(request.method.rawValue) \(request.path)\(suffix)")
+        logInfo("\(connection.identifier) request: \(request.method.rawValue) \(request.path)\(suffix)")
     }
 
     func logError(_ error: any Error, on connection: HTTPConnection) {
-        logError("\(connection.identifer) error: \(error.localizedDescription)")
+        logError("\(connection.identifier) error: \(error.localizedDescription)")
     }
 
     func logListening(on socket: Socket) {
@@ -391,7 +391,7 @@ extension Logging {
 }
 
 private extension HTTPConnection {
-    var identifer: String {
+    var identifier: String {
         "<\(hostname)>"
     }
 }

--- a/FlyingFox/Tests/HTTPConnectionTests.swift
+++ b/FlyingFox/Tests/HTTPConnectionTests.swift
@@ -134,13 +134,13 @@ struct HTTPConnectionTests {
     @Test
     func connectionHostName() {
         #expect(
-            HTTPConnection.makeIdentifer(from: .ip4("8.8.8.8", port: 8080)) == "8.8.8.8"
+            HTTPConnection.makeIdentifier(from: .ip4("8.8.8.8", port: 8080)) == "8.8.8.8"
         )
         #expect(
-            HTTPConnection.makeIdentifer(from: .ip6("::1", port: 8080)) == "::1"
+            HTTPConnection.makeIdentifier(from: .ip6("::1", port: 8080)) == "::1"
         )
         #expect(
-            HTTPConnection.makeIdentifer(from: .unix("/var/sock/fox")) == "/var/sock/fox"
+            HTTPConnection.makeIdentifier(from: .unix("/var/sock/fox")) == "/var/sock/fox"
         )
     }
 }


### PR DESCRIPTION
Fixing typo.  This is part of an internal interface so we are doing a simple rename rather than keeping the original misspelling with a deprecation notice.