### PR TITLE
WSMessage: drop unnecessary @unchecked Sendable

### DIFF
--- a/FlyingFox/Sources/WebSocket/WSMessage.swift
+++ b/FlyingFox/Sources/WebSocket/WSMessage.swift
@@ -31,7 +31,7 @@
 
 import Foundation
 
-public enum WSMessage: @unchecked Sendable, Hashable {
+public enum WSMessage: Sendable, Hashable {
     case text(String)
     case data(Data)
     case close(WSCloseCode = .normalClosure)


### PR DESCRIPTION
All associated values (String, Data, WSCloseCode) are Sendable, so the @unchecked opt-out is no longer needed.