### PR TITLE
Remove redundant @unchecked Sendable annotations

### DIFF
--- a/FlyingFox/Sources/HTTPConnection.swift
+++ b/FlyingFox/Sources/HTTPConnection.swift
@@ -110,7 +110,7 @@ extension HTTPConnection: Hashable {
     }
 }
 
-actor HTTPRequestSequence<S: AsyncBufferedSequence & Sendable>: AsyncSequence, AsyncIteratorProtocol, @unchecked Sendable where S.Element == UInt8 {
+actor HTTPRequestSequence<S: AsyncBufferedSequence & Sendable>: AsyncSequence, AsyncIteratorProtocol where S.Element == UInt8 {
     typealias Element = HTTPRequest
     private let bytes: S
     private let remoteAddress: HTTPRequest.Address?

--- a/FlyingFox/Sources/HTTPResponse.swift
+++ b/FlyingFox/Sources/HTTPResponse.swift
@@ -37,7 +37,7 @@ public struct HTTPResponse: Sendable {
     public var headers: HTTPHeaders
     public var payload: Payload
 
-    public enum Payload: @unchecked Sendable {
+    public enum Payload: Sendable {
         case httpBody(HTTPBodySequence)
         case webSocket(any WSHandler)
 

--- a/FlyingFox/Sources/WebSocket/WSMessage.swift
+++ b/FlyingFox/Sources/WebSocket/WSMessage.swift
@@ -31,7 +31,7 @@
 
 import Foundation
 
-public enum WSMessage: @unchecked Sendable, Hashable {
+public enum WSMessage: Sendable, Hashable {
     case text(String)
     case data(Data)
     case close(WSCloseCode = .normalClosure)

--- a/FlyingSocks/Sources/Logging+OSLog.swift
+++ b/FlyingSocks/Sources/Logging+OSLog.swift
@@ -33,7 +33,7 @@
 import OSLog
 
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
-public struct OSLogLogger: Logging, @unchecked Sendable {
+public struct OSLogLogger: Logging {
 
     private var logger: Logger
 


### PR DESCRIPTION
## Summary

Removes `@unchecked Sendable` annotations from four sites where the declaration is either redundant (the containing type is already Sendable by other means) or correct with a plain `Sendable` conformance (all contained values are Sendable).

| File:Line | Before | After |
|-----------|--------|-------|
| `HTTPResponse.swift:40` | `public enum Payload: @unchecked Sendable` | `public enum Payload: Sendable` |
| `WSMessage.swift:34` | `public enum WSMessage: @unchecked Sendable, Hashable` | `public enum WSMessage: Sendable, Hashable` |
| `HTTPConnection.swift:113` | `actor HTTPRequestSequence<...>: AsyncSequence, AsyncIteratorProtocol, @unchecked Sendable` | `actor HTTPRequestSequence<...>: AsyncSequence, AsyncIteratorProtocol` |
| `Logging+OSLog.swift:36` | `public struct OSLogLogger: Logging, @unchecked Sendable` | `public struct OSLogLogger: Logging` |

## Rationale (primary-source verified)

- **`HTTPResponse.Payload`**: `.httpBody(HTTPBodySequence)` — `HTTPBodySequence: Sendable` (HTTPBodySequence.swift:35). `.webSocket(any WSHandler)` — `WSHandler: Sendable` (WSHandler.swift:34).
- **`WSMessage`**: associated values are `String`, `Data`, `WSCloseCode`. `WSCloseCode: Sendable` (WSCloseCode.swift:34); `String` / `Data` are Sendable.
- **`HTTPRequestSequence`**: per SE-0306, *"every actor type implicitly conforms to the Sendable protocol."* Explicit `@unchecked Sendable` (or even explicit `Sendable`) on an actor is redundant.
- **`OSLogLogger`**: `os.Logger` is declared `public struct Logger : @unchecked Swift.Sendable` in the Xcode SDK `os.swiftmodule` interface, and the `Logging` protocol already requires `Sendable` (Logging.swift:32) — so both the `@unchecked` and the explicit `Sendable` conformance were redundant.

## Test plan

- [x] `swift build` clean (no warnings, 5.16 s).
- [x] `swift test` — 404 tests across 49 suites, all pass (1.13 s total).
- [ ] CI on the upstream repo.

## Scope

This is Group A of a broader `@unchecked Sendable` audit. The remaining 12 sites fall into two categories:

- **Group B** — replace with synchronized state (e.g., `Mutex`-wrapped storage): `HTTPBodySequence.Storage`, `AsyncStream+WSFrame.Iterator`, `WSFrameValidator.Validator`. To be submitted separately.
- **Group C** — keep `@unchecked` with a justifying comment (`Transferring`, `Mutex` variants, `ConsumingAsyncSequence.SharedBuffer`/`State`, retroactive `sockaddr_*` conformances). To be submitted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)