### PR TITLE
Fix typo: "must must" -> "must" in WS handshake error message

### DIFF
--- a/FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift
@@ -95,7 +95,7 @@ public struct WebSocketHTTPHandler: HTTPHandler, Sendable {
         // 4. A |Connection| header field that includes the token "Upgrade", treated as an ASCII
         //    case-insensitive value.
         guard let connectionHeader = headers[.connection] else {
-            throw WSInvalidHandshakeError("Connection header must must be present")
+            throw WSInvalidHandshakeError("Connection header must be present")
         }
 
         let connectionHeaderTokens = connectionHeader.lowercased().split(separator: ",").map { token in


### PR DESCRIPTION
## Summary

- Fixes a duplicated word (`must must`) in the `WSInvalidHandshakeError` thrown when a WebSocket handshake request is missing its `Connection` header.

## Change

`FlyingFox/Sources/Handlers/WebSocketHTTPHandler.swift:98`:

```diff
-    throw WSInvalidHandshakeError("Connection header must must be present")
+    throw WSInvalidHandshakeError("Connection header must be present")
```

## Test plan

- [x] `swift build` clean.
- [x] `swift test` — 404 tests across 49 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)