### PR TITLE
Return 416 for unsatisfiable Range; clamp end to file size

### DIFF
--- a/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
@@ -162,11 +162,18 @@ public struct FileHTTPHandler: HTTPHandler {
             }
 
             if let range = Self.makePartialRange(for: request.headers, fileSize: fileSize) {
-                headers[.contentRange] = "bytes \(range.lowerBound)-\(range.upperBound)/\(fileSize)"
+                guard range.lowerBound < fileSize else {
+                    return HTTPResponse(
+                        statusCode: .rangeNotSatisfiable,
+                        headers: HTTPHeaders([.contentRange: "bytes */\(fileSize)"])
+                    )
+                }
+                let upperBound = min(range.upperBound, fileSize - 1)
+                headers[.contentRange] = "bytes \(range.lowerBound)-\(upperBound)/\(fileSize)"
                 return try HTTPResponse(
                     statusCode: .partialContent,
                     headers: headers,
-                    body: HTTPBodySequence(file: path, range: range.lowerBound..<range.upperBound + 1)
+                    body: HTTPBodySequence(file: path, range: range.lowerBound..<upperBound + 1)
                 )
             } else {
                 return try HTTPResponse(

--- a/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/HTTPHandlerTests.swift
@@ -236,6 +236,25 @@ struct HTTPHandlerTests {
         try await #expect(response.bodyString == "cakes")
     }
 
+    @Test
+    func fileHandler_Returns416WhenRangeStartExceedsFileSize() async throws {
+        let handler = FileHTTPHandler(named: "Stubs/fish.json", in: .module)
+
+        let response = try await handler.handleRequest(.make(headers: [.range: "bytes=20-30"]))
+        #expect(response.statusCode == .rangeNotSatisfiable)
+        #expect(response.headers[.contentRange] == "bytes */17")
+    }
+
+    @Test
+    func fileHandler_ClampsRangeEndToFileSize() async throws {
+        let handler = FileHTTPHandler(named: "Stubs/fish.json", in: .module)
+
+        let response = try await handler.handleRequest(.make(headers: [.range: "bytes=0-100"]))
+        #expect(response.statusCode == .partialContent)
+        #expect(response.headers[.contentRange] == "bytes 0-16/17")
+        try await #expect(response.bodyString == #"{"fish": "cakes"}"#)
+    }
+
     //MARK: - ProxyHTTPHandler
     
     @Test(.disabled("pie.dev appears to be down"))


### PR DESCRIPTION
## Summary

`FileHTTPHandler` previously returned **404 Not Found** for two distinct range-request scenarios. Both should be handled per RFC 9110 §14.1.2 and §15.5.17:

1. **Last-byte-pos past EOF** — should clamp to `fileSize - 1` and return 206.
2. **First-byte-pos at or past EOF** — should return **416 Range Not Satisfiable** with `Content-Range: bytes */<size>`.

## RFC references

- §14.1.2: *"If the last-pos value is absent, or if the value is greater than or equal to the current length of the representation data, the byte range is interpreted as the remainder of the representation (i.e., the server replaces the value of last-pos with a value that is one less than the current length of the selected representation)."*
- §14.1.2: *"a valid bytes range-spec is satisfiable if it is either: an int-range with a first-pos that is less than the current length of the selected representation or a suffix-range with a non-zero suffix-length."*
- §15.5.17: *"A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation."* — example: `Content-Range: bytes */47022`.

## Change

`FlyingFox/Sources/Handlers/FileHTTPHandler.swift` (6 new lines, 2 lines adjusted):

- On `range.lowerBound >= fileSize`: return 416 with `Content-Range: bytes */<size>`.
- Otherwise clamp the upper bound to `min(range.upperBound, fileSize - 1)` before constructing the 206 response + body sequence.

`makePartialRange` itself is unchanged — the handler owns the 416 / clamp logic where `fileSize` is already in scope.

## Tests

Two new tests in `FlyingFox/Tests/Handlers/HTTPHandlerTests.swift`. Both fail against the pre-fix code (return 404) and pass after the fix:

- `fileHandler_Returns416WhenRangeStartExceedsFileSize`: `bytes=20-30` on a 17-byte file → 416, `Content-Range: bytes */17`.
- `fileHandler_ClampsRangeEndToFileSize`: `bytes=0-100` on a 17-byte file → 206, `Content-Range: bytes 0-16/17`, full body.

## Out of scope (follow-ups)

- Suffix ranges (`bytes=-500`) and multi-range (`bytes=0-0,-1`) — not handled here.
- `DirectoryHTTPHandler` has no range support yet; when it gains that (tracked separately), the same 416/clamp logic should be factored out rather than duplicated.

## Test plan

- [x] `swift build` clean.
- [x] New tests pass.
- [x] `swift test` — 406 tests across 49 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)