### PR TITLE
Fix path-prefix match in Directory/RedirectHTTPHandler

### DIFF
--- a/FlyingFox/Sources/Handlers/DirectoryHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/DirectoryHTTPHandler.swift
@@ -91,16 +91,11 @@ public struct DirectoryHTTPHandler: HTTPHandler {
     }
 
     func makeFileURL(for requestPath: String) -> URL? {
-        let compsA = serverPath
-            .split(separator: "/", omittingEmptySubsequences: true)
-            .joined(separator: "/")
+        let serverComponents = serverPath.split(separator: "/", omittingEmptySubsequences: true)
+        let requestComponents = requestPath.split(separator: "/", omittingEmptySubsequences: true)
 
-        let compsB = requestPath
-            .split(separator: "/", omittingEmptySubsequences: true)
-            .joined(separator: "/")
-
-        guard compsB.hasPrefix(compsA) else { return nil }
-        let subPath = String(compsB.dropFirst(compsA.count))
+        guard requestComponents.starts(with: serverComponents) else { return nil }
+        let subPath = requestComponents.dropFirst(serverComponents.count).joined(separator: "/")
         return root?.appendingPathComponent(subPath)
     }
     

--- a/FlyingFox/Sources/Handlers/RedirectHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/RedirectHTTPHandler.swift
@@ -82,24 +82,19 @@ public struct RedirectHTTPHandler: HTTPHandler {
             throw URLError(.badURL)
         }
 
-        let compsA = serverPath
-            .split(separator: "/", omittingEmptySubsequences: true)
-            .joined(separator: "/")
+        let serverComponents = serverPath.split(separator: "/", omittingEmptySubsequences: true)
+        let requestComponents = request.path.split(separator: "/", omittingEmptySubsequences: true)
 
-        let compsB = request.path
-            .split(separator: "/", omittingEmptySubsequences: true)
-            .joined(separator: "/")
-
-        guard !compsA.isEmpty else {
+        guard !serverComponents.isEmpty else {
             return try base.appendingRequest(request)
         }
 
-        guard compsB.hasPrefix(compsA) else {
+        guard requestComponents.starts(with: serverComponents) else {
             throw URLError(.badURL)
         }
 
         var request = request
-        request.path = String(compsB.dropFirst(compsA.count))
+        request.path = requestComponents.dropFirst(serverComponents.count).joined(separator: "/")
         return try base.appendingRequest(request)
     }
 

--- a/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
@@ -103,6 +103,20 @@ struct DirectoryHTTPHandlerTests {
     }
 
     @Test
+    func fileURL_rejectsServerPathSiblings() {
+        let handler = DirectoryHTTPHandler(root: URL(fileURLWithPath: "/temp"),
+                                           serverPath: "/sub/folder")
+
+        #expect(
+            handler.makeFileURL(for: "/sub/folderx/secret") == nil
+        )
+
+        #expect(
+            handler.makeFileURL(for: "/sub/folder-extra/secret") == nil
+        )
+    }
+
+    @Test
     func serverPath_doesNotRequier_leadingSlash() {
         let handler = DirectoryHTTPHandler(root: URL(fileURLWithPath: "/temp"),
                                            serverPath: "sub/folder")

--- a/FlyingFox/Tests/Handlers/RedirectHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RedirectHTTPHandlerTests.swift
@@ -84,6 +84,19 @@ struct RedirectHTTPHandlerTests {
     }
 
     @Test
+    func base_rejectsServerPathSiblings() async throws {
+        let handler: any HTTPHandler = .redirect(via: "http://fish.com", serverPath: "chips/shrimp")
+
+        await #expect(throws: URLError.self) {
+            try await handler.handleRequest(.make(path: "/chips/shrimpx/1"))
+        }
+
+        await #expect(throws: URLError.self) {
+            try await handler.handleRequest(.make(path: "/chips/shrimp-extra/1"))
+        }
+    }
+
+    @Test
     func base_statuscode() async throws {
         let handler = RedirectHTTPHandler(base: "http://fish.com", statusCode: .temporaryRedirect, serverPath: "/chips/shrimp")
 


### PR DESCRIPTION
## Summary
- Both `DirectoryHTTPHandler.makeFileURL` and `RedirectHTTPHandler.makeRedirectLocation` compared request path against server path using `String.hasPrefix` on joined path strings, which does not enforce component boundaries. `serverPath: "/sub/folder"` + request `/sub/folderx/secret` incorrectly matched and resolved to `root/x/secret`.
- Fix compares path components directly with `Array.starts(with:)` and rebuilds the tail from the remaining components.
- Adds regression tests covering sibling names (`/sub/folderx/...`, `/sub/folder-extra/...`) for both handlers.

Closes TVT-283

## Test plan
- [x] `swift test` — full suite (406 tests) passes
- [x] New `fileURL_rejectsServerPathSiblings` fails before fix, passes after
- [x] New `base_rejectsServerPathSiblings` fails before fix, passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)