### PR TITLE
Fix percent-encoded path traversal in DirectoryHTTPHandler

### DIFF
--- a/FlyingFox/Sources/HTTPDecoder+StandardizePath.swift
+++ b/FlyingFox/Sources/HTTPDecoder+StandardizePath.swift
@@ -34,31 +34,24 @@ import Foundation
 
 extension HTTPDecoder {
 
+    // Decode percent-escapes before RFC 3986 §5.2.4 dot-segment removal.
+    // URL.standardized and URL.path would otherwise round-trip the encoding:
+    // dot-segment removal runs on the percent-encoded path (see the
+    // swift-foundation reference below, which this file's removingDotSegments
+    // helper is copied from), so "%2e%2e" is opaque to the normalizer, and
+    // URL.path then percent-decodes on the way out, smuggling a literal ".."
+    // past normalization. Without this pre-decode, handlers that map
+    // request.path to the filesystem — presently only DirectoryHTTPHandler —
+    // are exposed to path traversal via percent-encoded dot sequences
+    // (TVT-289). Using removingDotSegments directly on the decoded string
+    // avoids a second decode round that would re-introduce the same issue
+    // for double-encoded inputs like "%252e%252e".
     static func standardizePath(_ path: String) -> String? {
-        standardizePath(path, fallback: false)
-    }
-
-    static func standardizePath(_ path: String, fallback: Bool) -> String? {
-        #if canImport(Darwin)
-            #if compiler(>=6.2)
-            if !fallback, #available(macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *) {
-                return URL(string: path)?.standardized.path
-            } else {
-                return standardizePathDarwinFallback(path)
-            }
-            #else
-            return standardizePathDarwinFallback(path)
-            #endif
-        #else
-        return URL(string: path)?.standardized.path
-        #endif
-    }
-
-    private static func standardizePathDarwinFallback(_ path: String) -> String? {
+        let decoded = path.removingPercentEncoding ?? path
         if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, visionOS 26.0, *) {
-            return URL(string: path.removingDotSegments)?.standardized.path
+            return decoded.removingDotSegments
         } else {
-            return URL(string: path)?.standardized.path
+            return URL(string: decoded)?.standardized.path
         }
     }
 }

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -298,8 +298,27 @@ struct HTTPDecoderTests {
         #expect(
             HTTPDecoder.standardizePath("/../a/b/../c/./d.html") == "/a/c/d.html"
         )
+    }
+
+    @Test
+    func standardizedPath_collapsesPercentEncodedDotSegments() {
+        // TVT-289 — percent-encoded dot segments must be decoded and collapsed
+        // before reaching handlers that map paths to the filesystem.
         #expect(
-            HTTPDecoder.standardizePath("/../a/b/../c/./d.html", fallback: true) == "/a/c/d.html"
+            HTTPDecoder.standardizePath("/served/%2e%2e/secret.txt") == "/secret.txt"
+        )
+        #expect(
+            HTTPDecoder.standardizePath("/served/%2E%2E/secret.txt") == "/secret.txt"
+        )
+        #expect(
+            HTTPDecoder.standardizePath("/served/%2e%2e%2fsecret.txt") == "/secret.txt"
+        )
+        #expect(
+            HTTPDecoder.standardizePath("/served/..%2fsecret.txt") == "/secret.txt"
+        )
+        // Double-encoded input must NOT collapse — it's a literal "%2e%2e" component.
+        #expect(
+            HTTPDecoder.standardizePath("/served/%252e%252e/secret.txt") == "/served/%2e%2e/secret.txt"
         )
     }
 }

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -321,6 +321,29 @@ struct HTTPDecoderTests {
             HTTPDecoder.standardizePath("/served/%252e%252e/secret.txt") == "/served/%2e%2e/secret.txt"
         )
     }
+
+    // Exercises branches of the vendored removingDotSegments state machine
+    // that standardizePath now routes through directly. Each case targets a
+    // distinct state transition so regressions in any branch surface here.
+    @Test(arguments: [
+        ("", ""),                     // isEmpty guard
+        (".", ""),                    // .initial → .dot (terminal)
+        ("..", ""),                   // .initial → .dot → .dotDot (terminal)
+        ("./foo", "foo"),             // .dot → .initial (leading "./" strip)
+        ("../foo", "foo"),            // .dot → .dotDot → .initial (leading "../" strip)
+        (".foo", ".foo"),             // .dot → .appendUntilSlash
+        ("..foo", "..foo"),           // .dotDot → .appendUntilSlash
+        ("/.hidden", "/.hidden"),     // .slashDot → .appendUntilSlash
+        ("/..hidden", "/..hidden"),   // .slashDotDot → .appendUntilSlash
+        ("/a//b", "/a//b"),           // .slash → .slash (double slash write)
+        ("/foo/..", "/"),             // terminal .slashDotDot (trailing "/..")
+        ("/./", "/"),                 // .slashDot → .slash then terminal .slash
+        ("/a/.", "/a/"),              // .slashDot terminal (trailing "/.")
+        ("/a%XY/b", "/a%XY/b")        // malformed %-encoding → `?? path` fallback
+    ])
+    func standardizedPath_stateMachineBranches(input: String, expected: String) {
+        #expect(HTTPDecoder.standardizePath(input) == expected)
+    }
 }
 
 private extension HTTPDecoder {

--- a/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
@@ -140,4 +140,39 @@ struct DirectoryHTTPHandlerTests {
             handler.makeFileURL(for: "sub/a") == URL(fileURLWithPath: "/temp/file/sub/a")
         )
     }
+
+    // TVT-289 — regression guard for percent-encoded path traversal.
+    // A sibling `secret.txt` is placed above the served root; traversal
+    // vectors are routed through HTTPDecoder + DirectoryHTTPHandler. Any
+    // response body equal to "SECRET" is a confirmed traversal.
+    @Test(arguments: [
+        "/served/%2e%2e/secret.txt",
+        "/served/%2E%2E/secret.txt",
+        "/served/%2e%2e%2fsecret.txt",
+        "/served/%252e%252e/secret.txt",
+        "/served/..%2fsecret.txt",
+        "/served/../secret.txt"
+    ])
+    func pathTraversalProbe(rawTarget: String) async throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("tvt289-\(UUID().uuidString)")
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let served = root.appendingPathComponent("served")
+        try fm.createDirectory(at: served, withIntermediateDirectories: true)
+        try "INSIDE".data(using: .utf8)!.write(to: served.appendingPathComponent("inside.txt"))
+        try "SECRET".data(using: .utf8)!.write(to: root.appendingPathComponent("secret.txt"))
+
+        let handler = DirectoryHTTPHandler(root: served, serverPath: "/served")
+
+        let decoder = HTTPDecoder()
+        let components = decoder.readComponents(from: rawTarget)
+        let request = HTTPRequest.make(path: components.path, query: components.query)
+
+        let response = try await handler.handleRequest(request)
+        let body = try await response.bodyString
+
+        #expect(body != "SECRET", "path traversal via \(rawTarget) — served sibling file above root")
+    }
 }


### PR DESCRIPTION
## Summary
Percent-encoded dot segments (e.g. `/served/%2e%2e/secret.txt`) pass through `HTTPDecoder.standardizePath` as literal `..`, because `URL.standardized` runs RFC 3986 §5.2.4 dot-segment removal on the percent-encoded path and `URL.path` decodes afterwards. `DirectoryHTTPHandler` then resolved the resulting `..` against its `root` and read files above the served directory.

- Decode percent-escapes once before normalization.
- Apply `removingDotSegments` directly on the decoded string rather than round-tripping through `URL`; that avoids a second decode round that re-introduces the traversal for double-encoded inputs (`%252e%252e`).
- Drop the now-unused `fallback:` parameter and Darwin branching that only existed to test the alternate path — both branches now produce the same result.

Affected handler (only): `DirectoryHTTPHandler`. `FileHTTPHandler` serves a fixed file; `RedirectHTTPHandler` and `ProxyHTTPHandler` don't map `request.path` to the filesystem.

Primary sources referenced in the code comment:
- swift-foundation `URL_Swift.swift` (`URL.standardized` implementation)
- Apple docs for `String.removingPercentEncoding`

Closes TVT-289

## Test plan
- [x] `swift test` — full suite (406 tests) passes
- [x] New `DirectoryHTTPHandlerTests.pathTraversalProbe` end-to-end guard over all 6 attack vectors (literal `..`, `%2e%2e`, `%2E%2E`, `%2e%2e%2f`, `..%2f`, and the double-encoded `%252e%252e` that must **not** collapse).
- [x] New `HTTPDecoderTests.standardizedPath_collapsesPercentEncodedDotSegments` pins the decoder contract at the unit level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)