### PR TITLE
Fix Big-Endian decoding for 8-byte WebSocket frame lengths

### DIFF
--- a/FlyingFox/Sources/WebSocket/WSFrameEncoder.swift
+++ b/FlyingFox/Sources/WebSocket/WSFrameEncoder.swift
@@ -142,14 +142,14 @@ struct WSFrameEncoder {
                                    UInt16(bytes.take())
             return try await (Int(length), hasMask ? decodeMask(from: bytes) : nil)
         default:
-            var length = try await UInt64(bytes.take())
-            length |= try await UInt64(bytes.take()) << 8
-            length |= try await UInt64(bytes.take()) << 16
-            length |= try await UInt64(bytes.take()) << 24
-            length |= try await UInt64(bytes.take()) << 32
-            length |= try await UInt64(bytes.take()) << 40
+            var length = try await UInt64(bytes.take()) << 56
             length |= try await UInt64(bytes.take()) << 48
-            length |= try await UInt64(bytes.take()) << 56
+            length |= try await UInt64(bytes.take()) << 40
+            length |= try await UInt64(bytes.take()) << 32
+            length |= try await UInt64(bytes.take()) << 24
+            length |= try await UInt64(bytes.take()) << 16
+            length |= try await UInt64(bytes.take()) << 8
+            length |= try await UInt64(bytes.take())
 
             guard length <= Int.max else {
                 throw Error("Length is greater than Int.max")

--- a/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
@@ -232,10 +232,16 @@ struct WSFrameEncoderTests {
     @Test
     func decodeLength() async throws {
         #expect(
+            try await WSFrameEncoder.decodeLength(0x00) == 0
+        )
+        #expect(
             try await WSFrameEncoder.decodeLength(0x01) == 1
         )
         #expect(
             try await WSFrameEncoder.decodeLength(0x7D) == 125
+        )
+        #expect(
+            try await WSFrameEncoder.decodeLength(0x7E, 0x00, 0x7E) == 126
         )
         #expect(
             try await WSFrameEncoder.decodeLength(0x7E, 0x00, 0xFF) == 0x00FF
@@ -247,7 +253,22 @@ struct WSFrameEncoderTests {
             try await WSFrameEncoder.decodeLength(0x7E, 0xFF, 0xFF) == 0xFFFF
         )
         #expect(
-            try await WSFrameEncoder.decodeLength(0x7F, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x00) == 0x0099AABBCCDDEEFF
+            try await WSFrameEncoder.decodeLength(0x7F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00) == 0x00010000
+        )
+        #expect(
+            try await WSFrameEncoder.decodeLength(0x7F, 0x00, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF) == 0x0099AABBCCDDEEFF
+        )
+        #expect(
+            try await WSFrameEncoder.decodeLength(0x7F, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF) == Int.max
+        )
+        #expect(
+            try await WSFrameEncoder.decodeLength(0x80, 0x00, 0x00, 0x00, 0x00) == 0x00
+        )
+        #expect(
+            try await WSFrameEncoder.decodeLength(0xFE, 0x00, 0x7E, 0x00, 0x00, 0x00, 0x00) == 0x7E
+        )
+        #expect(
+            try await WSFrameEncoder.decodeLength(0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7F, 0x00, 0x00, 0x00, 0x00) == 0x7F
         )
     }
 
@@ -257,7 +278,16 @@ struct WSFrameEncoderTests {
             try await WSFrameEncoder.decodeLength(0x7E)
         }
         await #expect(throws: SocketError.disconnected) {
+            try await WSFrameEncoder.decodeLength(0x7E, 0x00)
+        }
+        await #expect(throws: SocketError.disconnected) {
             try await WSFrameEncoder.decodeLength(0x7F, 0xFF, 0xFF, 0xFF)
+        }
+        await #expect(throws: SocketError.disconnected) {
+            try await WSFrameEncoder.decodeLength(0x7F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+        }
+        await #expect(throws: WSFrameEncoder.Error.self) {
+            try await WSFrameEncoder.decodeLength(0x7F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
         }
         await #expect(throws: WSFrameEncoder.Error.self) {
             try await WSFrameEncoder.decodeLength(0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in WebSocket frame length decoding where 64-bit (8-byte) extended payload lengths were incorrectly interpreted as Little-Endian instead of Big-Endian (Network Byte Order), as required by RFC 6455.

## Changes
- **WSFrameEncoder**: Updated `decodeLengthMask` to use Big-Endian bit shifts for the 64-bit payload length path.
- **WSFrameEncoderTests**: Normalized existing tests to Big-Endian and supplemented with comprehensive edge cases:
    - Minimum and maximum boundaries (0, 126, 65,536, and `Int.max`).
    - Truncated data handling for both 16-bit and 64-bit decoding paths.
    - Validation that the mask bit (0x80) is correctly handled and does not corrupt length decoding.

## Rationale
Per **RFC 6455 §5.2**, the "Extended payload length" fields must be interpreted as unsigned integers in network byte order. The previous implementation for the 64-bit field was using Little-Endian, causing incorrect length calculations for any WebSocket frame larger than 65,535 bytes.

## Verification
- Verified by adding a robust suite of unit tests in `WSFrameEncoderTests.swift`.
- All tests pass, ensuring correct decoding for all valid frame sizes and proper error handling for malformed frames.
