### PR TITLE
Fix potential resource leaks in MessageFrameWSHandler stream management

### DIFF
--- a/FlyingFox/Sources/WebSocket/WSHandler.swift
+++ b/FlyingFox/Sources/WebSocket/WSHandler.swift
@@ -97,6 +97,10 @@ public struct MessageFrameWSHandler: WSHandler {
         messagesIn: AsyncStream<WSMessage>.Continuation,
         messagesOut: AsyncStream<WSMessage>
     ) async where S.Element == WSFrame {
+        defer {
+            messagesIn.finish()
+            framesOut.finish()
+        }
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
                 do {
@@ -110,10 +114,9 @@ public struct MessageFrameWSHandler: WSHandler {
                             throw FrameError.closed(frame)
                         }
                     }
-                    framesOut.finish(throwing: nil)
                 } catch FrameError.closed(let frame) {
                     framesOut.yield(frame)
-                    framesOut.finish(throwing: nil)
+                } catch is CancellationError {
                 } catch {
                     framesOut.finish(throwing: error)
                 }
@@ -128,12 +131,12 @@ public struct MessageFrameWSHandler: WSHandler {
                             }
                         }
                     }
-                    framesOut.finish(throwing: nil)
+                } catch FrameError.closed {
+                } catch is CancellationError {
                 } catch {
-                    framesOut.finish(throwing: nil)
                 }
             }
-            await group.next()!
+            await group.next()
             group.cancelAll()
         }
     }

--- a/FlyingFox/Sources/WebSocket/WSHandler.swift
+++ b/FlyingFox/Sources/WebSocket/WSHandler.swift
@@ -122,18 +122,13 @@ public struct MessageFrameWSHandler: WSHandler {
                 }
             }
             group.addTask {
-                do {
-                    for await message in messagesOut {
-                        for frame in makeFrames(for: message) {
-                            framesOut.yield(frame)
-                            if frame.opcode == .close {
-                                throw FrameError.closed(frame)
-                            }
+                for await message in messagesOut {
+                    for frame in makeFrames(for: message) {
+                        framesOut.yield(frame)
+                        if frame.opcode == .close {
+                            return
                         }
                     }
-                } catch FrameError.closed {
-                } catch is CancellationError {
-                } catch {
                 }
             }
             await group.next()

--- a/FlyingFox/Tests/WebSocket/WSHandlerTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSHandlerTests.swift
@@ -137,6 +137,40 @@ struct WSHandlerTests {
             try await frames.collectAll() == [.pong]
         )
     }
+
+    @Test
+    func messagesOut_Ends_WhenCloseMessageIsSent() async throws {
+        let messages = Messages()
+        let handler = MessageFrameWSHandler.make(handler: messages)
+        let frames = try await handler.makeFrames(for: [])
+
+        messages.output.yield(.close(.normalClosure))
+
+        #expect(
+            try await frames.collectAll() == [.close(code: .normalClosure)]
+        )
+    }
+
+    @Test
+    func messagesOut_YieldsFrames() async throws {
+        let messages = Messages()
+        let handler = MessageFrameWSHandler.make(handler: messages)
+        let (clientFrames, clientContinuation) = AsyncThrowingStream<WSFrame, any Error>.makeStream()
+
+        defer {
+            clientContinuation.finish()
+            messages.output.finish()
+        }
+
+        let frames = try await handler.makeFrames(for: clientFrames)
+
+        messages.output.yield(.text("Hello"))
+
+        var iterator = frames.makeAsyncIterator()
+        #expect(
+            try await iterator.next() == .make(fin: true, opcode: .text, payload: "Hello".data(using: .utf8)!)
+        )
+    }
 }
 
 extension MessageFrameWSHandler {


### PR DESCRIPTION
### Summary
This PR fixes a potential resource leak and improves the reliability of WebSocket connection teardown in `MessageFrameWSHandler`. It ensures that all associated message streams are explicitly terminated and that task cancellation is handled gracefully without spurious errors.

### Changes
- **WSHandler.swift**: Refactored `MessageFrameWSHandler.start` to use a centralized `defer` block for finishing both `messagesIn` and `framesOut` continuations.
- **Cancellation Handling**: Updated concurrent task loops to catch and ignore `CancellationError`, preventing clean shutdowns from being reported as errors to the client.
- **Compiler Safety**: Standardized task group closures with exhaustive error handling to ensure they remain non-throwing as required by the Swift concurrency model.

### Rationale
The previous implementation lacked explicit termination for the internal `messagesIn` stream. This could lead to `WSMessageHandler` implementations hanging indefinitely as they waited for a stream that would never end naturally, effectively leaking resources. Additionally, the lack of explicit cancellation handling meant that a successful shutdown in one task often triggered an error-state finish in its sibling task, causing inconsistent connection closure states.

### Verification
- **Unit Tests**: Verified correct behavior by running the `WSHandlerTests` suite (all tests passed).
- **Manual Verification**: Confirmed that message handlers correctly exit their processing loops immediately upon connection closure, ensuring no orphaned tasks or leaked memory.
