### PR TITLE
Honor HTTP/1.1 persistent-connection default per RFC 9112 §9.3

### DIFF
--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -129,7 +129,15 @@ public extension HTTPRequest {
 }
 
 extension HTTPRequest {
+    // RFC 9112 §9.3 — HTTP/1.1 connections persist unless `Connection: close`;
+    // HTTP/1.0 connections close unless `Connection: keep-alive` is present.
     var shouldKeepAlive: Bool {
-        headers[.connection]?.caseInsensitiveCompare("keep-alive") == .orderedSame
+        let tokens = (headers[.connection] ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+        if version == .http11 {
+            return !tokens.contains("close")
+        }
+        return tokens.contains("keep-alive")
     }
 }

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -243,7 +243,9 @@ public final actor HTTPServer {
 
     func handleRequest(_ request: HTTPRequest) async -> HTTPResponse {
         var response = await handleRequest(request, timeout: config.timeout)
-        if request.shouldKeepAlive {
+        // Echo the request's Connection header on keep-alive responses, but only
+        // if the handler did not set its own (e.g. WebSocket upgrade → "upgrade").
+        if request.shouldKeepAlive, response.headers[.connection] == nil {
             response.headers[.connection] = request.headers[.connection]
         }
         return response

--- a/FlyingFox/Tests/HTTPConnectionTests.swift
+++ b/FlyingFox/Tests/HTTPConnectionTests.swift
@@ -83,6 +83,7 @@ struct HTTPConnectionTests {
             Connection: Keep-Alive\r
             \r
             GET /hello HTTP/1.1\r
+            Connection: close\r
             \r
 
             """

--- a/FlyingFox/Tests/HTTPRequestTests.swift
+++ b/FlyingFox/Tests/HTTPRequestTests.swift
@@ -88,4 +88,61 @@ struct HTTPRequestTests {
         #expect(request.target.query() == "food=fish%20%26%20chips&qty=15")
         #expect(request.target.query(percentEncoded: false) == "food=fish & chips&qty=15")
     }
+
+    // RFC 9112 §9.3 — HTTP/1.1 connections persist by default; only `Connection: close` opts out.
+    @Test
+    func http11_keepsAliveByDefault_whenConnectionHeaderAbsent() {
+        let request = HTTPRequest.make(version: .http11, headers: [:])
+        #expect(request.shouldKeepAlive)
+    }
+
+    @Test
+    func http11_closes_whenConnectionHeaderIsClose() {
+        let request = HTTPRequest.make(version: .http11, headers: [.connection: "close"])
+        #expect(!request.shouldKeepAlive)
+    }
+
+    @Test
+    func http11_closes_whenConnectionHeaderIsCloseMixedCase() {
+        let request = HTTPRequest.make(version: .http11, headers: [.connection: "Close"])
+        #expect(!request.shouldKeepAlive)
+    }
+
+    @Test
+    func http11_keepsAlive_whenConnectionHeaderIsKeepAlive() {
+        let request = HTTPRequest.make(version: .http11, headers: [.connection: "keep-alive"])
+        #expect(request.shouldKeepAlive)
+    }
+
+    // RFC 9110 §7.6.1 — Connection is a comma-separated list of options.
+    @Test
+    func http11_keepsAlive_withMultiTokenConnectionHeader() {
+        let request = HTTPRequest.make(version: .http11, headers: [.connection: "keep-alive, Upgrade"])
+        #expect(request.shouldKeepAlive)
+    }
+
+    @Test
+    func http11_closes_whenCloseTokenAppearsAmongOthers() {
+        let request = HTTPRequest.make(version: .http11, headers: [.connection: "Upgrade, close"])
+        #expect(!request.shouldKeepAlive)
+    }
+
+    // RFC 9112 §9.3 — HTTP/1.0 closes by default; only `Connection: keep-alive` opts in.
+    @Test
+    func http10_closesByDefault_whenConnectionHeaderAbsent() {
+        let request = HTTPRequest.make(version: HTTPVersion("HTTP/1.0"), headers: [:])
+        #expect(!request.shouldKeepAlive)
+    }
+
+    @Test
+    func http10_keepsAlive_whenConnectionHeaderIsKeepAlive() {
+        let request = HTTPRequest.make(version: HTTPVersion("HTTP/1.0"), headers: [.connection: "keep-alive"])
+        #expect(request.shouldKeepAlive)
+    }
+
+    @Test
+    func http10_closes_whenConnectionHeaderIsClose() {
+        let request = HTTPRequest.make(version: HTTPVersion("HTTP/1.0"), headers: [.connection: "close"])
+        #expect(!request.shouldKeepAlive)
+    }
 }


### PR DESCRIPTION
## Summary

- `HTTPRequest.shouldKeepAlive` now follows RFC 9112 §9.3: HTTP/1.1 connections persist unless `Connection: close`; HTTP/1.0 connections close unless `Connection: keep-alive` is present. The Connection header is split on commas so multi-token values like `Keep-Alive, Upgrade` are handled (RFC 9110 §7.6.1).
- `HTTPServer.handleRequest` no longer overwrites a Connection header that the handler explicitly set (e.g. WebSocket's `Upgrade`). It only echoes the request's Connection token when the response has none.
- Previously, an HTTP/1.1 client that omitted `Connection: keep-alive` (the compliant default) would have the connection closed after one request. With multi-token headers, even `Keep-Alive, Upgrade` failed the equality check.

Closes TVT-288.

## Test plan

- [x] Add 9 `HTTPRequestTests` cases covering HTTP/1.1 default, multi-token, and HTTP/1.0 semantics.
- [x] Update `connectionRequestsAreReceived_WhileConnectionIsKeptAlive` to terminate via `Connection: close` instead of relying on the previous (buggy) behavior.
- [x] Full suite: 417 tests, 49 suites, all passing locally.