### PR TITLE
Decode chunked request bodies; reject invalid framing per RFC 9112

### DIFF
--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -69,6 +69,14 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
         )
     }
 
+    init(chunked bytes: some AsyncBufferedSequence<UInt8>, suggestedBufferSize: Int = 4096) {
+        self.storage = Storage(
+            bytes: HTTPChunkedTransferDecoder(bytes: bytes),
+            count: nil,
+            bufferSize: suggestedBufferSize
+        )
+    }
+
     public init(file url: URL, range: Range<Int>? = nil, suggestedBufferSize: Int = 4096) throws {
         self.storage = try Storage(
             fileURL: url,

--- a/FlyingFox/Sources/HTTPChunkedDecodedSequence.swift
+++ b/FlyingFox/Sources/HTTPChunkedDecodedSequence.swift
@@ -1,0 +1,132 @@
+//
+//  HTTPChunkedDecodedSequence.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 24/04/2026.
+//  Copyright © 2026 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import FlyingSocks
+
+// Decodes an `AsyncBufferedSequence` of bytes that are framed using the
+// `chunked` transfer coding (RFC 9112 §7.1) and yields the decoded payload.
+struct HTTPChunkedTransferDecoder<Base>: AsyncBufferedSequence, Sendable
+    where Base: AsyncBufferedSequence,
+          Base.Element == UInt8,
+          Base: Sendable {
+    typealias Element = UInt8
+
+    private let bytes: Base
+
+    init(bytes: Base) {
+        self.bytes = bytes
+    }
+
+    func makeAsyncIterator() -> Iterator {
+        Iterator(bytes: bytes.makeAsyncIterator())
+    }
+}
+
+extension HTTPChunkedTransferDecoder {
+
+    struct Iterator: AsyncBufferedIteratorProtocol {
+
+        private var bytes: Base.AsyncIterator
+        private var remainingInChunk: Int = 0
+        private var isComplete: Bool = false
+
+        init(bytes: Base.AsyncIterator) {
+            self.bytes = bytes
+        }
+
+        mutating func next() async throws -> UInt8? {
+            fatalError("call nextBuffer(suggested:)")
+        }
+
+        mutating func nextBuffer(suggested count: Int) async throws -> [UInt8]? {
+            guard !isComplete else { return nil }
+
+            if remainingInChunk == 0 {
+                let size = try await readChunkSize()
+                if size == 0 {
+                    try await consumeTrailer()
+                    isComplete = true
+                    return nil
+                }
+                remainingInChunk = size
+            }
+
+            let take = Swift.min(count, remainingInChunk)
+            guard let buffer = try await bytes.nextBuffer(count: take) else {
+                throw HTTPDecoder.Error("Unexpected end of chunked body")
+            }
+            remainingInChunk -= buffer.count
+            if remainingInChunk == 0 {
+                try await consumeCRLF()
+            }
+            return buffer
+        }
+
+        // RFC 9112 §7.1: chunk = chunk-size [ chunk-ext ] CRLF chunk-data CRLF
+        // chunk-size is hexadecimal; chunk-ext (preceded by `;`) is ignored here.
+        private mutating func readChunkSize() async throws -> Int {
+            let line = try await readLine()
+            let sizePart = line.split(separator: ";", maxSplits: 1).first.map(String.init) ?? line
+            guard let size = Int(sizePart, radix: 16), size >= 0 else {
+                throw HTTPDecoder.Error("Invalid chunk-size: \(line)")
+            }
+            return size
+        }
+
+        // RFC 9112 §7.1.2: trailer-section is zero or more field lines terminated by CRLF.
+        private mutating func consumeTrailer() async throws {
+            while !(try await readLine()).isEmpty { }
+        }
+
+        private mutating func consumeCRLF() async throws {
+            guard let buffer = try await bytes.nextBuffer(count: 2),
+                  buffer == [0x0D, 0x0A] else {
+                throw HTTPDecoder.Error("Expected CRLF after chunk-data")
+            }
+        }
+
+        private mutating func readLine() async throws -> String {
+            var line = [UInt8]()
+            while true {
+                guard let buffer = try await bytes.nextBuffer(count: 1) else {
+                    throw HTTPDecoder.Error("Unexpected end of chunked body")
+                }
+                let byte = buffer[0]
+                if byte == 0x0A {
+                    if line.last == 0x0D { line.removeLast() }
+                    return String(decoding: line, as: UTF8.self)
+                }
+                line.append(byte)
+            }
+        }
+    }
+}

--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -50,7 +50,11 @@ struct HTTPDecoder {
         let version = HTTPVersion(String(comps[2]))
         let target = makeTarget(from: comps[1])
         let headers = try await readHeaders(from: bytes)
-        let body = try await readBody(from: bytes, length: headers[.contentLength])
+        let body = try await readBody(
+            from: bytes,
+            contentLength: headers[.contentLength],
+            transferEncoding: headers[.transferEncoding]
+        )
 
         return HTTPRequest(
             method: method,
@@ -74,7 +78,11 @@ struct HTTPDecoder {
         let statusCode = HTTPStatusCode(code, phrase: String(comps[2]))
 
         let headers = try await readHeaders(from: bytes)
-        let body = try await readBody(from: bytes, length: headers[.contentLength])
+        let body = try await readBody(
+            from: bytes,
+            contentLength: headers[.contentLength],
+            transferEncoding: headers[.transferEncoding]
+        )
 
         return HTTPResponse(
             version: version,
@@ -127,11 +135,46 @@ struct HTTPDecoder {
             .reduce(into: [HTTPHeader: String]()) { $0[$1.header] = $1.value }
     }
 
-    func readBody(from bytes: some AsyncBufferedSequence<UInt8>, length: String?) async throws -> HTTPBodySequence {
-        let length = length.flatMap(Int.init) ?? 0
+    func readBody(
+        from bytes: some AsyncBufferedSequence<UInt8>,
+        contentLength: String?,
+        transferEncoding: String?
+    ) async throws -> HTTPBodySequence {
         guard sharedRequestBufferSize > 0 else {
             throw SocketError.disconnected
         }
+
+        // RFC 9112 §6.1 — reject simultaneous Content-Length and Transfer-Encoding.
+        if transferEncoding != nil && contentLength != nil {
+            throw Error("Content-Length and Transfer-Encoding cannot both be present")
+        }
+
+        // RFC 9112 §6.3 #3 — Transfer-Encoding takes precedence. §6.1 requires
+        // `chunked` to be the final coding when present; only `chunked` is supported here.
+        if let transferEncoding {
+            let tokens = transferEncoding
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+            guard tokens.last == "chunked" else {
+                throw Error("Unsupported Transfer-Encoding: \(transferEncoding)")
+            }
+            return HTTPBodySequence(
+                chunked: bytes,
+                suggestedBufferSize: sharedRequestBufferSize
+            )
+        }
+
+        // RFC 9112 §6.3 #5 — invalid Content-Length is an unrecoverable framing error.
+        let length: Int
+        if let contentLength {
+            guard let parsed = Int(contentLength), parsed >= 0 else {
+                throw Error("Invalid Content-Length: \(contentLength)")
+            }
+            length = parsed
+        } else {
+            length = 0
+        }
+
         if length <= sharedRequestBufferSize {
             return try await HTTPBodySequence(data: readData(from: bytes, length: length), suggestedBufferSize: length)
         } else if length <= sharedRequestReplaySize {

--- a/FlyingFox/Sources/HTTPServer.swift
+++ b/FlyingFox/Sources/HTTPServer.swift
@@ -234,6 +234,9 @@ public final actor HTTPServer {
                 try await connection.sendResponse(response)
             }
         } catch {
+            // TODO: send `400 Bad Request` on `HTTPDecoder.Error` before closing.
+            // Closing without a response is RFC 9112 §6.3 #5-compliant for unrecoverable
+            // framing errors, but a 400 response would be more informative.
             logger.logError(error, on: connection)
         }
         connections.remove(connection)

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -402,6 +402,109 @@ struct HTTPDecoderTests {
             )
         }
     }
+
+    // RFC 9112 §7.1 — `chunk-ext` (preceded by `;`) is permitted on the chunk-size line.
+    @Test
+    func chunkExt_IsIgnored() async throws {
+        let request = try await HTTPDecoder.make().decodeRequestFromString(
+            """
+            POST /hello HTTP/1.1\r
+            Transfer-Encoding: chunked\r
+            \r
+            5;name=value\r
+            Hello\r
+            0\r
+            \r
+
+            """
+        )
+
+        #expect(try await request.bodyString == "Hello")
+    }
+
+    @Test
+    func invalidChunkSize_ThrowsError() async throws {
+        let request = try await HTTPDecoder.make().decodeRequestFromString(
+            """
+            POST /hello HTTP/1.1\r
+            Transfer-Encoding: chunked\r
+            \r
+            XX\r
+            \r
+
+            """
+        )
+
+        await #expect(throws: HTTPDecoder.Error.self) {
+            _ = try await request.bodyData
+        }
+    }
+
+    @Test
+    func missingCRLFAfterChunkData_ThrowsError() async throws {
+        let request = try await HTTPDecoder.make().decodeRequestFromString(
+            """
+            POST /hello HTTP/1.1\r
+            Transfer-Encoding: chunked\r
+            \r
+            5\r
+            HelloAB
+            """
+        )
+
+        await #expect(throws: HTTPDecoder.Error.self) {
+            _ = try await request.bodyData
+        }
+    }
+
+    // Truncated chunked-body: chunk-size line never terminates → SocketError.disconnected.
+    @Test
+    func truncatedChunkSize_ThrowsError() async throws {
+        let request = try await HTTPDecoder.make().decodeRequestFromString(
+            """
+            POST /hello HTTP/1.1\r
+            Transfer-Encoding: chunked\r
+            \r
+            5
+            """
+        )
+
+        await #expect(throws: SocketError.self) {
+            _ = try await request.bodyData
+        }
+    }
+
+    // Truncated chunked-body: stream ends inside chunk-data → SocketError.disconnected.
+    @Test
+    func truncatedChunkData_ThrowsError() async throws {
+        let request = try await HTTPDecoder.make().decodeRequestFromString(
+            """
+            POST /hello HTTP/1.1\r
+            Transfer-Encoding: chunked\r
+            \r
+            5\r
+            Hi
+            """
+        )
+
+        await #expect(throws: SocketError.self) {
+            _ = try await request.bodyData
+        }
+    }
+
+    // RFC 9112 §6.1 — only `chunked` transfer coding is supported here.
+    @Test
+    func unsupportedTransferEncoding_ThrowsError() async throws {
+        await #expect(throws: HTTPDecoder.Error.self) {
+            try await HTTPDecoder.make().decodeRequestFromString(
+                """
+                POST /hello HTTP/1.1\r
+                Transfer-Encoding: gzip\r
+                \r
+                """
+            )
+        }
+    }
 }
 
 private extension HTTPDecoder {

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -187,10 +187,10 @@ struct HTTPDecoderTests {
     @Test
     func body_ThrowsError_WhenSequenceEnds() async throws {
         await #expect(throws: SocketError.self) {
-            try await HTTPDecoder.make(sharedRequestReplaySize: 1024).readBody(from: AsyncBufferedEmptySequence(completeImmediately: true), length: "100").get()
+            try await HTTPDecoder.make(sharedRequestReplaySize: 1024).readBody(from: AsyncBufferedEmptySequence(completeImmediately: true), contentLength: "100", transferEncoding: nil).get()
         }
         await #expect(throws: SocketError.self) {
-            try await HTTPDecoder.make(sharedRequestBufferSize: 1024).readBody(from: AsyncBufferedEmptySequence(completeImmediately: true), length: "100").get()
+            try await HTTPDecoder.make(sharedRequestBufferSize: 1024).readBody(from: AsyncBufferedEmptySequence(completeImmediately: true), contentLength: "100", transferEncoding: nil).get()
         }
     }
 
@@ -302,6 +302,106 @@ struct HTTPDecoderTests {
             HTTPDecoder.standardizePath("/../a/b/../c/./d.html", fallback: true) == "/a/c/d.html"
         )
     }
+
+    // RFC 9112 §7.1 — chunked-coded request bodies are decoded into the body data.
+    @Test
+    func body_IsParsed_WhenTransferEncoding_IsChunked() async throws {
+        let request = try await HTTPDecoder.make().decodeRequestFromString(
+            """
+            POST /hello HTTP/1.1\r
+            Transfer-Encoding: chunked\r
+            \r
+            5\r
+            Hello\r
+            7\r
+             World!\r
+            0\r
+            \r
+
+            """
+        )
+
+        #expect(try await request.bodyString == "Hello World!")
+    }
+
+    @Test
+    func body_IsEmpty_WhenChunkedTerminatorOnly() async throws {
+        let request = try await HTTPDecoder.make().decodeRequestFromString(
+            """
+            POST /hello HTTP/1.1\r
+            Transfer-Encoding: chunked\r
+            \r
+            0\r
+            \r
+
+            """
+        )
+
+        #expect(try await request.bodyData == Data())
+    }
+
+    // RFC 9112 §7.1.2 — trailer fields are consumed but not part of the body.
+    @Test
+    func chunkedBody_IgnoresTrailerHeaders() async throws {
+        let request = try await HTTPDecoder.make().decodeRequestFromString(
+            """
+            POST /hello HTTP/1.1\r
+            Transfer-Encoding: chunked\r
+            \r
+            5\r
+            Hello\r
+            0\r
+            X-Trailer: ignored\r
+            \r
+
+            """
+        )
+
+        #expect(try await request.bodyString == "Hello")
+    }
+
+    // RFC 9112 §6.1 — reject simultaneous Content-Length and Transfer-Encoding (smuggling prevention).
+    @Test
+    func contentLengthAndTransferEncoding_ThrowsError() async throws {
+        await #expect(throws: HTTPDecoder.Error.self) {
+            try await HTTPDecoder.make().decodeRequestFromString(
+                """
+                POST /hello HTTP/1.1\r
+                Content-Length: 5\r
+                Transfer-Encoding: chunked\r
+                \r
+                Hello
+                """
+            )
+        }
+    }
+
+    // RFC 9112 §6.3 #5 — invalid Content-Length is an unrecoverable framing error.
+    @Test
+    func nonNumericContentLength_ThrowsError() async throws {
+        await #expect(throws: HTTPDecoder.Error.self) {
+            try await HTTPDecoder.make().decodeRequestFromString(
+                """
+                POST /hello HTTP/1.1\r
+                Content-Length: abc\r
+                \r
+                """
+            )
+        }
+    }
+
+    @Test
+    func negativeContentLength_ThrowsError() async throws {
+        await #expect(throws: HTTPDecoder.Error.self) {
+            try await HTTPDecoder.make().decodeRequestFromString(
+                """
+                POST /hello HTTP/1.1\r
+                Content-Length: -5\r
+                \r
+                """
+            )
+        }
+    }
 }
 
 private extension HTTPDecoder {
@@ -318,7 +418,8 @@ private extension HTTPDecoder {
         let data = string.data(using: .utf8)!
         return try await readBody(
             from: ConsumingAsyncSequence(data),
-            length: "\(data.count)"
+            contentLength: "\(data.count)",
+            transferEncoding: nil
         )
     }
 }


### PR DESCRIPTION
## Summary

- `HTTPDecoder.readBody` now honors `Transfer-Encoding: chunked` (RFC 9112 §7.1) by routing the body through a new `HTTPChunkedTransferDecoder` — the read-side mirror of the existing `HTTPChunkedTransferEncoder`. Trailer fields (RFC 9112 §7.1.2) are consumed and discarded.
- `readBody` also throws `HTTPDecoder.Error` on framing violations:
  - both `Content-Length` and `Transfer-Encoding` present (§6.1, smuggling prevention)
  - non-numeric or negative `Content-Length` (§6.3 #5, "unrecoverable error")
  - `Transfer-Encoding` whose final coding is not `chunked` (§6.1)
- Throwing surfaces as a connection-close, which is RFC-permitted for unrecoverable framing errors. `HTTPServer.handleConnection` has a `// TODO` to upgrade this to an explicit `400 Bad Request` response in a future change.
- `readBody`'s signature changes from `(from:length:)` to `(from:contentLength:transferEncoding:)`. Both `decodeRequest` and `decodeResponse` now pass the relevant headers.

Closes TVT-287.

## Test plan

- [x] Six new `HTTPDecoderTests` cases covering chunked multi-chunk decode, terminator-only, trailer ignore, conflicting CL+TE, non-numeric CL, negative CL.
- [x] Existing `readBody`/test-helper call sites updated to the new signature.
- [x] Full suite: 414 tests, 49 suites, all passing locally.