### PR TITLE
Compute ETag from (mtime, size) to skip whole-file load per request

### DIFF
--- a/FlyingFox/Sources/HTTPCacheControl.swift
+++ b/FlyingFox/Sources/HTTPCacheControl.swift
@@ -6,9 +6,6 @@
 //
 
 import Foundation
-#if canImport(CryptoKit)
-import CryptoKit
-#endif
 
 public enum HTTPCacheControl {
     public enum ResponseDirective: Sendable, CustomStringConvertible {
@@ -88,14 +85,25 @@ public enum HTTPCacheControl {
         return nil
     }
 
-    static func getETagValue(for data: Data) -> String? {
-#if canImport(CryptoKit)
-        let sha256digest = SHA256.hash(data: data)
-        let eTag = "\"\(sha256digest.map { String(format: "%02x", $0) }.joined())\""
-        return eTag
-#else
-        return nil
-#endif
+    // Strong ETag derived from (mtime, size), matching the format used by
+    // nginx (`"%xT-%xO"`, see ngx_http_set_etag in src/http/ngx_http_core_module.c)
+    // and Apache HTTPD's default `FileETag MTime Size`. Cheap to compute and
+    // does not require reading file contents.
+    static func getETagValue(for filePath: URL) -> String? {
+        let path = {
+            if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+                return filePath.path()
+            } else {
+                return filePath.path
+            }
+        }()
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let modificationDate = attributes[.modificationDate] as? Date,
+              let size = attributes[.size] as? UInt64 else {
+            return nil
+        }
+        let mtime = Int64(modificationDate.timeIntervalSince1970)
+        return String(format: "\"%llx-%llx\"", mtime, size)
     }
 }
 

--- a/FlyingFox/Sources/Handlers/DirectoryHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/DirectoryHTTPHandler.swift
@@ -75,7 +75,7 @@ public struct DirectoryHTTPHandler: HTTPHandler {
             }
         }
 
-        if let eTagValue = HTTPCacheControl.getETagValue(for: data) {
+        if let eTagValue = HTTPCacheControl.getETagValue(for: filePath) {
             headers[.eTag] = eTagValue
             if let ifNoneMatch = request.headers[.ifNoneMatch], eTagValue == ifNoneMatch {
                 return HTTPResponse(statusCode: .notModified,

--- a/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/FileHTTPHandler.swift
@@ -142,8 +142,7 @@ public struct FileHTTPHandler: HTTPHandler {
                 }
             }
 
-            if let data = try? Data(contentsOf: path),
-                let eTagValue = HTTPCacheControl.getETagValue(for: data) {
+            if let eTagValue = HTTPCacheControl.getETagValue(for: path) {
                 headers[.eTag] = eTagValue
                 if let ifNoneMatch = request.headers[.ifNoneMatch], eTagValue == ifNoneMatch {
                     return HTTPResponse(statusCode: .notModified,

--- a/FlyingFox/Tests/HTTPCacheControlTests.swift
+++ b/FlyingFox/Tests/HTTPCacheControlTests.swift
@@ -1,0 +1,117 @@
+//
+//  HTTPCacheControlTests.swift
+//  FlyingFox
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+
+@testable import FlyingFox
+import Foundation
+import Testing
+
+struct HTTPCacheControlTests {
+
+    @Test
+    func getETagValue_returnsNil_whenFileIsMissing() {
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("flyingfox-etag-missing-\(UUID().uuidString)")
+        #expect(HTTPCacheControl.getETagValue(for: missing) == nil)
+    }
+
+    @Test
+    func getETagValue_isStrong_quoted_andHasNoWeakPrefix() throws {
+        let url = try Self.makeTempFile(contents: Data("hello".utf8))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let etag = try #require(HTTPCacheControl.getETagValue(for: url))
+
+        // Strong validator: starts/ends with a literal double quote, no W/ prefix.
+        // Matches nginx "<hex-mtime>-<hex-size>" inside double quotes.
+        #expect(etag.hasPrefix("\""))
+        #expect(etag.hasSuffix("\""))
+        #expect(!etag.hasPrefix("W/"))
+
+        let inner = etag.dropFirst().dropLast()
+        let parts = inner.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+        #expect(parts.count == 2)
+        #expect(parts.allSatisfy { Self.isLowerHex($0) })
+    }
+
+    @Test
+    func getETagValue_isStable_forSameFile() throws {
+        let url = try Self.makeTempFile(contents: Data("stable".utf8))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(HTTPCacheControl.getETagValue(for: url) == HTTPCacheControl.getETagValue(for: url))
+    }
+
+    @Test
+    func getETagValue_differs_whenSizeDiffers() throws {
+        let mtime = Date(timeIntervalSince1970: 1_700_000_000)
+        let small = try Self.makeTempFile(contents: Data("a".utf8), modificationDate: mtime)
+        defer { try? FileManager.default.removeItem(at: small) }
+        let bigger = try Self.makeTempFile(contents: Data("ab".utf8), modificationDate: mtime)
+        defer { try? FileManager.default.removeItem(at: bigger) }
+
+        let etagSmall = try #require(HTTPCacheControl.getETagValue(for: small))
+        let etagBigger = try #require(HTTPCacheControl.getETagValue(for: bigger))
+        #expect(etagSmall != etagBigger)
+    }
+
+    @Test
+    func getETagValue_differs_whenMtimeDiffers() throws {
+        let url = try Self.makeTempFile(
+            contents: Data("same-bytes".utf8),
+            modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+        let earlier = try #require(HTTPCacheControl.getETagValue(for: url))
+
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_800_000_000)],
+            ofItemAtPath: url.path
+        )
+        let later = try #require(HTTPCacheControl.getETagValue(for: url))
+
+        #expect(earlier != later)
+    }
+
+    // The defining behavior of a metadata ETag: equal mtime + equal size → equal ETag,
+    // even if the file contents differ. This is exactly the property a SHA-256-of-contents
+    // ETag does NOT have.
+    @Test
+    func getETagValue_collides_whenMtimeAndSizeMatchButContentsDiffer() throws {
+        let mtime = Date(timeIntervalSince1970: 1_700_000_000)
+        let a = try Self.makeTempFile(contents: Data("AAAAA".utf8), modificationDate: mtime)
+        defer { try? FileManager.default.removeItem(at: a) }
+        let b = try Self.makeTempFile(contents: Data("BBBBB".utf8), modificationDate: mtime)
+        defer { try? FileManager.default.removeItem(at: b) }
+
+        let etagA = try #require(HTTPCacheControl.getETagValue(for: a))
+        let etagB = try #require(HTTPCacheControl.getETagValue(for: b))
+        #expect(etagA == etagB)
+    }
+
+    private static func makeTempFile(
+        contents: Data,
+        modificationDate: Date? = nil
+    ) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("flyingfox-etag-\(UUID().uuidString)")
+        try contents.write(to: url)
+        if let modificationDate {
+            try FileManager.default.setAttributes(
+                [.modificationDate: modificationDate],
+                ofItemAtPath: url.path
+            )
+        }
+        return url
+    }
+
+    private static func isLowerHex(_ s: Substring) -> Bool {
+        !s.isEmpty && s.allSatisfy { $0.isHexDigit && (!$0.isLetter || $0.isLowercase) }
+    }
+}


### PR DESCRIPTION
Note that this PR exchanges performance for accuracy.  It changes ETag to be based on modification time & size rather than a proper SHA. This technique is also used by Apache and nginx.

This PR would also simplify updating the directory handler to adopt streaming as the file handler already does.

## Summary

- Replace SHA-256-over-contents ETag with `"<hex-mtime>-<hex-size>"`, matching nginx (`ngx_http_set_etag` in `src/http/ngx_http_core_module.c`) and Apache HTTPD's default `FileETag MTime Size`.
- `FileHTTPHandler` and `DirectoryHTTPHandler` no longer call `Data(contentsOf:)` solely to compute an ETag.
- Strong validator (no `W/` prefix) so `If-Range` keeps working for `FileHTTPHandler`'s Range path.

Closes TVT-290.

## Test plan

- [x] New `HTTPCacheControlTests` (6 tests): nil for missing file; quoted strong format with hex-hex inner; stable for unchanged file; differs on size change; differs on mtime change; collides when mtime+size match but contents differ (the property that distinguishes a metadata ETag from a content-hash ETag).
- [x] `swift test` — 435 tests pass.
- [x] `swift build` — clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)