### PR TITLE
Stream DirectoryHTTPHandler responses via HTTPBodySequence(file:)

### DIFF
--- a/FlyingFox/Sources/Handlers/DirectoryHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/DirectoryHTTPHandler.swift
@@ -55,39 +55,41 @@ public struct DirectoryHTTPHandler: HTTPHandler {
     }
 
     public func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
-        guard
-            let filePath = makeFileURL(for: request.path),
-            let data = try? Data(contentsOf: filePath) else {
+        guard let filePath = makeFileURL(for: request.path) else {
             return HTTPResponse(statusCode: .notFound)
         }
 
-        var headers: HTTPHeaders = [
-            .contentType: FileHTTPHandler.makeContentType(for: filePath.absoluteString),
-            .cacheControl: cacheControl.getSerializedValue(),
-            .date: HTTPCacheControl.getDateHeaderValue()
-        ]
+        do {
+            var headers: HTTPHeaders = [
+                .contentType: FileHTTPHandler.makeContentType(for: filePath.absoluteString),
+                .cacheControl: cacheControl.getSerializedValue(),
+                .date: HTTPCacheControl.getDateHeaderValue()
+            ]
 
-        if let expiresValue = HTTPCacheControl.getExpiresValue(for: filePath) {
-            headers[.lastModified] = expiresValue
-            if let ifModifiedSince = request.headers[.ifModifiedSince], expiresValue == ifModifiedSince {
-                return HTTPResponse(statusCode: .notModified,
-                                    headers: headers)
+            if let expiresValue = HTTPCacheControl.getExpiresValue(for: filePath) {
+                headers[.lastModified] = expiresValue
+                if let ifModifiedSince = request.headers[.ifModifiedSince], expiresValue == ifModifiedSince {
+                    return HTTPResponse(statusCode: .notModified,
+                                        headers: headers)
+                }
             }
-        }
 
-        if let eTagValue = HTTPCacheControl.getETagValue(for: filePath) {
-            headers[.eTag] = eTagValue
-            if let ifNoneMatch = request.headers[.ifNoneMatch], eTagValue == ifNoneMatch {
-                return HTTPResponse(statusCode: .notModified,
-                                    headers: headers)
+            if let eTagValue = HTTPCacheControl.getETagValue(for: filePath) {
+                headers[.eTag] = eTagValue
+                if let ifNoneMatch = request.headers[.ifNoneMatch], eTagValue == ifNoneMatch {
+                    return HTTPResponse(statusCode: .notModified,
+                                        headers: headers)
+                }
             }
-        }
 
-        return HTTPResponse(
-            statusCode: .ok,
-            headers: headers,
-            body: data
-        )
+            return try HTTPResponse(
+                statusCode: .ok,
+                headers: headers,
+                body: HTTPBodySequence(file: filePath)
+            )
+        } catch {
+            return HTTPResponse(statusCode: .notFound)
+        }
     }
 
     func makeFileURL(for requestPath: String) -> URL? {

--- a/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
@@ -73,6 +73,18 @@ struct DirectoryHTTPHandlerTests {
     }
 
     @Test
+    func directoryHandler_streamsBody_fromFile() async throws {
+        let handler = DirectoryHTTPHandler(bundle: .module, subPath: "Stubs", serverPath: "server/path")
+
+        let response = try await handler.handleRequest(.make(path: "server/path/fish.json"))
+        guard case .httpBody(let body) = response.payload else {
+            Issue.record("expected .httpBody payload")
+            return
+        }
+        #expect(body.storage.sequence is AsyncBufferedFileSequence)
+    }
+
+    @Test
     func directoryHandler_Returns404WhenFileDoesNotExist() async throws {
         let handler = DirectoryHTTPHandler.directory(for: .module, subPath: "Stubs", serverPath: "server/path")
 

--- a/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/DirectoryHTTPHandlerTests.swift
@@ -85,6 +85,70 @@ struct DirectoryHTTPHandlerTests {
     }
 
     @Test
+    func directoryHandler_setsCacheHeaders_on200() async throws {
+        let handler = DirectoryHTTPHandler(bundle: .module, subPath: "Stubs", serverPath: "server/path")
+
+        let response = try await handler.handleRequest(.make(path: "server/path/fish.json"))
+        #expect(response.statusCode == .ok)
+        #expect(response.headers[.cacheControl]?.isEmpty == false)
+        #expect(response.headers[.date]?.isEmpty == false)
+        #expect(response.headers[.lastModified]?.isEmpty == false)
+        #expect(response.headers[.eTag]?.isEmpty == false)
+    }
+
+    @Test
+    func directoryHandler_returns304_whenIfModifiedSinceMatches() async throws {
+        let handler = DirectoryHTTPHandler(bundle: .module, subPath: "Stubs", serverPath: "server/path")
+
+        let initial = try await handler.handleRequest(.make(path: "server/path/fish.json"))
+        let lastModified = try #require(initial.headers[.lastModified])
+
+        let response = try await handler.handleRequest(.make(
+            path: "server/path/fish.json",
+            headers: [.ifModifiedSince: lastModified]
+        ))
+        #expect(response.statusCode == .notModified)
+        #expect(response.headers[.lastModified] == lastModified)
+    }
+
+    @Test
+    func directoryHandler_returns200_whenIfModifiedSinceDoesNotMatch() async throws {
+        let handler = DirectoryHTTPHandler(bundle: .module, subPath: "Stubs", serverPath: "server/path")
+
+        let response = try await handler.handleRequest(.make(
+            path: "server/path/fish.json",
+            headers: [.ifModifiedSince: "Mon, 01 Jan 1990 00:00:00 GMT"]
+        ))
+        #expect(response.statusCode == .ok)
+    }
+
+    @Test
+    func directoryHandler_returns304_whenIfNoneMatchMatches() async throws {
+        let handler = DirectoryHTTPHandler(bundle: .module, subPath: "Stubs", serverPath: "server/path")
+
+        let initial = try await handler.handleRequest(.make(path: "server/path/fish.json"))
+        let etag = try #require(initial.headers[.eTag])
+
+        let response = try await handler.handleRequest(.make(
+            path: "server/path/fish.json",
+            headers: [.ifNoneMatch: etag]
+        ))
+        #expect(response.statusCode == .notModified)
+        #expect(response.headers[.eTag] == etag)
+    }
+
+    @Test
+    func directoryHandler_returns200_whenIfNoneMatchDoesNotMatch() async throws {
+        let handler = DirectoryHTTPHandler(bundle: .module, subPath: "Stubs", serverPath: "server/path")
+
+        let response = try await handler.handleRequest(.make(
+            path: "server/path/fish.json",
+            headers: [.ifNoneMatch: "\"deadbeef-0\""]
+        ))
+        #expect(response.statusCode == .ok)
+    }
+
+    @Test
     func directoryHandler_Returns404WhenFileDoesNotExist() async throws {
         let handler = DirectoryHTTPHandler.directory(for: .module, subPath: "Stubs", serverPath: "server/path")
 


### PR DESCRIPTION
## Summary

- `DirectoryHTTPHandler` now streams responses via `HTTPBodySequence(file:)` instead of `Data(contentsOf:)`, matching `FileHTTPHandler`. Multi-gigabyte assets no longer load fully into memory per request.
- Existence-check folds into the `HTTPBodySequence(file:)` throw, mirroring `FileHTTPHandler`'s `do/catch → 404` pattern (no TOCTOU window).
- Built on TVT-290's `(mtime, size)` ETag — that change removed the last reason `DirectoryHTTPHandler` needed `Data` in scope.

Closes TVT-286.

## Test plan

- [x] New `directoryHandler_streamsBody_fromFile` test asserts `response.payload`'s body sequence is an `AsyncBufferedFileSequence` (was `AsyncBufferedCollection<Data>` before this change). Confirmed failing on `main`, passing after the fix.
- [x] Existing `DirectoryHTTPHandlerTests` (file content, content-type, 404, sub-directory, server-path matching) all still pass.
- [x] `swift test` — 440 tests pass.
- [x] `swift build` — clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)