### PR TITLE
Reject control frames with payload >125 bytes per RFC 6455 §5.5

### DIFF
--- a/FlyingFox/Sources/WebSocket/WSFrameValidator.swift
+++ b/FlyingFox/Sources/WebSocket/WSFrameValidator.swift
@@ -45,6 +45,16 @@ struct WSFrameValidator: Sendable {
 
         @Sendable
         func validateFrame(_ frame: WSFrame) throws -> WSFrame? {
+            switch frame.opcode {
+            case .ping, .pong, .close:
+                // RFC 6455 §5.5: control frame payload MUST be ≤ 125 bytes.
+                guard frame.payload.count <= 125 else {
+                    throw Error("Control frame payload exceeds 125 bytes")
+                }
+            default:
+                break
+            }
+
             if frame.opcode == .continuation {
                 try appendContinuation(frame)
                 guard let last = last, frame.fin else {

--- a/FlyingFox/Tests/WebSocket/WSFrameValidatorTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSFrameValidatorTests.swift
@@ -81,6 +81,31 @@ struct WSFrameValidatorTests {
     }
 
     @Test
+    func controlFrames_throwError_whenPayloadExceeds125Bytes() async {
+        // RFC 6455 §5.5: control frames MUST have payload length ≤ 125 bytes.
+        let oversized = Data(repeating: 0x41, count: 126)
+        await #expect(throws: WSFrameValidator.Error.self) {
+            try await WSFrameValidator.validate([.make(opcode: .ping, payload: oversized)]).collectAll()
+        }
+        await #expect(throws: WSFrameValidator.Error.self) {
+            try await WSFrameValidator.validate([.make(opcode: .pong, payload: oversized)]).collectAll()
+        }
+        await #expect(throws: WSFrameValidator.Error.self) {
+            try await WSFrameValidator.validate([.make(opcode: .close, payload: oversized)]).collectAll()
+        }
+    }
+
+    @Test
+    func controlFrames_areAccepted_whenPayloadIsAtMost125Bytes() async throws {
+        let maxPayload = Data(repeating: 0x41, count: 125)
+        let ping = WSFrame.make(opcode: .ping, payload: maxPayload)
+        let emptyPing = WSFrame.make(opcode: .ping)
+        #expect(
+            try await WSFrameValidator.validate([ping, emptyPing]).collectAll() == [ping, emptyPing]
+        )
+    }
+
+    @Test
     func controlFrames_ThrowError_WhenNotFin() async {
         await #expect(throws: WSFrameValidator.Error.self) {
             try await WSFrameValidator.validate([.make(fin: false, opcode: .ping)]).collectAll()


### PR DESCRIPTION
## Summary

- `WSFrameValidator` now rejects ping/pong/close frames with payload > 125 bytes, throwing `WSFrameValidator.Error`.
- Without this guard, a peer could send a 1 MB ping and have it echoed back verbatim as a pong by `WSHandler.makeResponseFrames`.
- RFC 6455 §5.5 (verified at https://www.rfc-editor.org/rfc/rfc6455#section-5.5): "All control frames MUST have a payload length of 125 bytes or less and MUST NOT be fragmented." The fragmentation rule is already enforced by `beginContinuation`; this PR fills the size-cap gap.

Closes TVT-306.

## Test plan

- [x] New `controlFrames_throwError_whenPayloadExceeds125Bytes` — 126-byte ping/pong/close each throw.
- [x] New `controlFrames_areAccepted_whenPayloadIsAtMost125Bytes` — boundary (125 bytes) and empty payload pass through unchanged.
- [x] Existing `controlFrames_ThrowError_WhenNotFin` still passes (fragmentation rejection is unchanged).
- [x] `swift test` — 441 tests pass.
- [x] `swift build` — clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)