### PR TITLE
Buffer HTTP request bytes once per connection

### DIFF
--- a/FlyingFox/Sources/HTTPConnection.swift
+++ b/FlyingFox/Sources/HTTPConnection.swift
@@ -36,18 +36,26 @@ struct HTTPConnection: Sendable {
 
     let hostname: String
     private let socket: AsyncSocket
+    private let bytes: AsyncBufferingSequence<AsyncSocketReadSequence>
     private let decoder: HTTPDecoder
     private let logger: any Logging
-    let requests: HTTPRequestSequence<AsyncSocketReadSequence>
+    let requests: HTTPRequestSequence<AsyncBufferingSequence<AsyncSocketReadSequence>>
 
     init(socket: AsyncSocket, decoder: HTTPDecoder, logger: some Logging) {
         self.socket = socket
         self.decoder = decoder
         self.logger = logger
 
+        // Wrap socket.bytes once per connection so header parsing, body
+        // reading, and any subsequent protocol upgrade all share a single
+        // 4 KB read buffer. Without this, the HTTP decoder pulls one byte
+        // per syscall through `iterator.next()` while parsing the status
+        // line and headers.
+        let bytes = AsyncBufferingSequence(socket.bytes)
         let (peer, identifier) = HTTPConnection.makeIdentifier(from: socket.socket)
         self.hostname = identifier
-        self.requests = HTTPRequestSequence(bytes: socket.bytes, decoder: decoder, remoteAddress: peer)
+        self.bytes = bytes
+        self.requests = HTTPRequestSequence(bytes: bytes, decoder: decoder, remoteAddress: peer)
     }
 
     func complete() async {
@@ -76,7 +84,9 @@ struct HTTPConnection: Sendable {
     }
 
     func switchToWebSocket(with handler: some WSHandler, response: Data) async throws {
-        let client = AsyncThrowingStream.decodingFrames(from: socket.bytes)
+        // Reuse the connection-wide buffered stream so any bytes already
+        // pulled past the upgrade request remain available to the WS framer.
+        let client = AsyncThrowingStream.decodingFrames(from: bytes)
         let server = try await handler.makeFrames(for: client)
         try await socket.write(response)
         logger.logSwitchProtocol(self, to: "websocket")

--- a/FlyingSocks/Sources/AsyncBufferingSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferingSequence.swift
@@ -1,0 +1,131 @@
+//
+//  AsyncBufferingSequence.swift
+//  FlyingFox
+//
+//  Wraps an AsyncBufferedSequence with a shared in-memory buffer so that
+//  multiple iterators created from the same wrapper consume from the same
+//  underlying stream without losing bytes pulled-but-not-yet-consumed when
+//  one iterator is dropped.
+//
+//  Distributed under the permissive MIT license.
+//
+
+private extension Transferring where Value: AsyncBufferedIteratorProtocol {
+    mutating func nextBuffer(suggested count: Int) async throws -> Transferring<Value.Buffer>? {
+        guard let buffer = try await value.nextBuffer(suggested: count) else { return nil }
+        return Transferring<Value.Buffer>(buffer)
+    }
+}
+
+/// AsyncBufferedSequence that adds a shared in-memory buffer over a base
+/// sequence. Bytes pulled from the base by one iterator remain available to
+/// subsequent iterators on the same wrapper — required when a consumer
+/// (e.g. the HTTP decoder) constructs multiple iterators against the same
+/// stream and must not lose bytes between them.
+///
+/// This is consuming, not replaying: each byte is returned to exactly one
+/// `next()` / `nextBuffer(suggested:)` call across all iterators.
+package struct AsyncBufferingSequence<Base>: AsyncBufferedSequence, Sendable
+where Base: AsyncBufferedSequence, Base.Element: Sendable {
+
+    package typealias Element = Base.Element
+
+    private let storage: Storage
+
+    package init(_ base: Base, suggestedBufferSize: Int = 4096) {
+        self.storage = Storage(base: base, suggestedBufferSize: suggestedBufferSize)
+    }
+
+    package func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(storage: storage)
+    }
+
+    package struct AsyncIterator: AsyncBufferedIteratorProtocol {
+        package typealias Buffer = ArraySlice<Element>
+
+        private let storage: Storage
+
+        init(storage: Storage) {
+            self.storage = storage
+        }
+
+        package mutating func next() async throws -> Element? {
+            try await storage.popOne()
+        }
+
+        package mutating func nextBuffer(suggested count: Int) async throws -> ArraySlice<Element>? {
+            try await storage.popBuffer(suggested: count)
+        }
+    }
+}
+
+extension AsyncBufferingSequence {
+
+    /// Storage actor backing one or more iterators against a base sequence.
+    ///
+    /// Designed for *serial* consumption from a single task graph (e.g. one
+    /// connection at a time): the actor's isolation guarantees a single in-flight
+    /// `refill` per wrapper, and the iterators created from `makeAsyncIterator()`
+    /// share the same backing buffer so bytes pulled from the base are never lost
+    /// between iterators.
+    final actor Storage {
+
+        private var iterator: Base.AsyncIterator?    // nil after EOF (or transiently during refill)
+        private var buffer: [Element] = []
+        private var consumed: Int = 0
+        private let suggestedBufferSize: Int
+
+        init(base: Base, suggestedBufferSize: Int) {
+            self.iterator = base.makeAsyncIterator()
+            self.suggestedBufferSize = suggestedBufferSize
+        }
+
+        private var available: Int { buffer.count - consumed }
+
+        func popOne() async throws -> Element? {
+            if available == 0, try await refill(suggested: suggestedBufferSize) == false {
+                return nil
+            }
+            let element = buffer[consumed]
+            consumed += 1
+            return element
+        }
+
+        func popBuffer(suggested count: Int) async throws -> ArraySlice<Element>? {
+            guard count > 0 else { return [] }
+            if available == 0,
+               try await refill(suggested: Swift.max(count, suggestedBufferSize)) == false {
+                return nil
+            }
+            let take = Swift.min(count, available)
+            let slice = buffer[consumed..<(consumed + take)]
+            consumed += take
+            return slice
+        }
+
+        // Returns true when bytes were pulled into the buffer, false at EOF.
+        // Wraps the iterator in `Transferring` to call a mutating async on a
+        // value-type iterator without tripping actor-isolation/sendability.
+        // Same idiom as AsyncSharedReplaySequence.requestNextChunk.
+        private func refill(suggested count: Int) async throws -> Bool {
+            guard let iter = iterator else { return false }
+            iterator = nil
+            var transferring = Transferring(iter)
+            let chunk: Base.AsyncIterator.Buffer?
+            do {
+                chunk = try await transferring.nextBuffer(suggested: count)?.value
+            } catch {
+                iterator = transferring.value
+                throw error
+            }
+            iterator = transferring.value
+            guard let chunk, !chunk.isEmpty else {
+                iterator = nil   // EOF
+                return false
+            }
+            buffer = Array(chunk)
+            consumed = 0
+            return true
+        }
+    }
+}


### PR DESCRIPTION
***AI disclosure: Claude-generated as part of analysis trying to reduce sys call overhead.***

## Summary

Wraps `socket.bytes` once per `HTTPConnection` in a new `AsyncBufferingSequence`, so that the multiple iterators the HTTP decoder creates during one request (status line, headers, body) all share a single ~4 KB read buffer instead of each calling through to the underlying socket on every byte.

## Motivation

`HTTPDecoder.decodeRequest` parses the status line and headers via `bytes.lines.takeNext()` / `readHeaders(from: bytes)`, which delegate to `CollectUntil.AsyncIterator.next()`:

```swift
while let element = try await iterator.next() {
    buffer.append(element)
    guard !until(buffer) else { break }
}
```

The base iterator is `AsyncSocketReadSequence.next()`:

```swift
public mutating func next() async throws -> UInt8? {
    return try await socket.read()        // ← one byte per syscall
}
```

`AsyncSocketReadSequence` already conforms to `AsyncBufferedSequence` and has a perfectly good `nextBuffer(suggested:)` that pulls up to 4 KB at a time, but the `next()` implementation ignores it and does an unbuffered single-byte `read(2)` for every byte.

For a typical HTTP/1.1 request with 200–500 bytes of status line + headers, this means 200–500 single-byte syscalls per request and, if a TCP segment boundary lands mid-header, a corresponding number of full `suspendSocket` actor-hop / `epoll_ctl MOD` / wakeup cycles. The body path is unaffected — `HTTPDecoder.readData` already uses `iterator.nextBuffer(count:)`.

A naive fix — adding an internal buffer to `AsyncSocketReadSequence.next()` — would lose bytes between iterators, because `HTTPDecoder` constructs a fresh iterator for the body reader (line 189) separate from the one used for the header parser, and `HTTPRequestSequence` creates a fresh iterator per request on a keepalive connection. Any bytes buffered-but-unconsumed when one iterator is dropped would be unreachable to the next.

## Approach

Add `AsyncBufferingSequence<Base>` to FlyingSocks: a small wrapper backed by an actor that owns one iterator into `Base` and a shared in-memory buffer. `makeAsyncIterator()` returns iterators whose `next()` and `nextBuffer(suggested:)` both consume from the shared backing buffer, so bytes pulled from `Base` are never lost between successive iterators on the same wrapper.

`HTTPConnection.init` wraps `socket.bytes` in `AsyncBufferingSequence` once and passes it to both `HTTPRequestSequence` and the WebSocket upgrade path, so any bytes pulled past the upgrade request remain available to the framer.

The wrapper uses the same `Transferring` idiom that `AsyncSharedReplaySequence.requestNextChunk` already uses to call mutating async functions on a value-type iterator across actor isolation. It is designed for serial consumption (one connection's parser at a time), which matches all current callers.

## Measurements

Profiled with `perf` against a release build of an MRP REST daemon hammering FlyingFox; 16-second captures, identical workload either side.

| | without buffering | with buffering | Δ |
|---|---|---|---|
| Total cycles | 45.84 × 10⁹ | 42.21 × 10⁹ | −7.9% |
| Avg CPU rate | 3056 Mc/s | 2649 Mc/s | **−13%** |
| `_dispatch_semaphore_wait_slow` (cum) | 25.2% | 24.3% | −0.9 pp |
| `HTTPDecoder.decodeRequest` self | (hidden in noise) | 0.0–0.02% | parser essentially disappears |

The proportional shape of the rest of the profile (SocketPool actor, continuation resumption, dispatch worker overhead) is unchanged — the win comes from eliminating the per-byte syscall + potential `suspendSocket` traffic during header parsing.

## Test plan

- [x] `swift test --package-path .` — 426/426 passing locally (Linux, Swift 6.x)
- [x] CI on macOS / iOS / tvOS / watchOS / Linux / Windows

## Notes / open questions

- `AsyncBufferingSequence` is `package`-scoped for now; happy to make it `public` if there's demand. There's nothing FlyingFox-specific about it — it's a general utility for "wrap an `AsyncBufferedSequence` so several iterators can share its buffer."
- Default `suggestedBufferSize` is 4096. Open to bikeshedding; could be configurable on `HTTPServer.Configuration`.
- The WebSocket upgrade path (`switchToWebSocket`) now reads frames from the same buffered stream rather than a fresh `socket.bytes`. Required for correctness if the buffer holds bytes past the upgrade request, and matches HTTP/1.1's "client MUST NOT send data after Upgrade until 101" rule.