### PR TITLE
Socket: treat read()/recv()==0 as EOF before consulting errno

### DIFF
--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -257,9 +257,12 @@ public struct Socket: Sendable, Hashable {
     private func read(into buffer: UnsafeMutablePointer<UInt8>, length: Int) throws -> Int {
         let count = Socket.read(file.rawValue, buffer, length)
         guard count > 0 else {
-            if errno == EWOULDBLOCK {
+            // count == 0 is EOF; errno is only valid after a -1 return.
+            if count == 0 {
+                throw SocketError.disconnected
+            } else if errno == EWOULDBLOCK {
                 throw SocketError.blocked
-            } else if errnoSignalsDisconnected() || count == 0 {
+            } else if errnoSignalsDisconnected() {
                 throw SocketError.disconnected
             } else {
                 throw SocketError.makeFailed("Read")
@@ -292,9 +295,12 @@ public struct Socket: Sendable, Hashable {
             Socket.recvfrom(file.rawValue, buffer, length, 0, $0, &size)
         }
         guard count > 0 else {
-            if errno == EWOULDBLOCK {
+            // count == 0 is EOF; errno is only valid after a -1 return.
+            if count == 0 {
+                throw SocketError.disconnected
+            } else if errno == EWOULDBLOCK {
                 throw SocketError.blocked
-            } else if errnoSignalsDisconnected() || count == 0 {
+            } else if errnoSignalsDisconnected() {
                 throw SocketError.disconnected
             } else {
                 throw SocketError.makeFailed("RecvFrom")
@@ -357,9 +363,12 @@ public struct Socket: Sendable, Hashable {
         }
 
         guard count > 0 else {
-            if errno == EWOULDBLOCK || errno == EAGAIN {
+            // count == 0 is EOF; errno is only valid after a -1 return.
+            if count == 0 {
+                throw SocketError.disconnected
+            } else if errno == EWOULDBLOCK || errno == EAGAIN {
                 throw SocketError.blocked
-            } else if errnoSignalsDisconnected() || count == 0 {
+            } else if errnoSignalsDisconnected() {
                 throw SocketError.disconnected
             } else {
                 throw SocketError.makeFailed("RecvMsg")

--- a/FlyingSocks/Sources/SocketPool+ePoll.swift
+++ b/FlyingSocks/Sources/SocketPool+ePoll.swift
@@ -31,6 +31,13 @@
 
 #if canImport(CSystemLinux)
 import CSystemLinux
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#endif
 
 public extension AsyncSocketPool where Self == SocketPool<ePoll> {
     static func ePoll(triggering: ePoll.TriggerMode = .edge, maxEvents limit: Int = 20, logger: some Logging = .disabled) -> SocketPool<ePoll> {
@@ -147,6 +154,11 @@ public struct ePoll: EventQueue {
         var events = Array(repeating: epoll_event(), count: eventsLimit)
         let status = CSystemLinux.epoll_wait(file.rawValue, &events, Int32(eventsLimit), -1)
         guard status > 0 else {
+            // EINTR (signal) is not a failure: report no events so the caller
+            // polls again rather than tearing down the server.
+            if status == -1 && errno == EINTR {
+                return []
+            }
             throw SocketError.makeFailed("epoll wait")
         }
 


### PR DESCRIPTION
A `read()`/`recvfrom()`/`recvmsg()` return of `0` is an orderly EOF, not an error, and does **not** set `errno`. The error-classification `guard` checked `errno == EWOULDBLOCK` *before* `count == 0`:

```swift
guard count > 0 else {
    if errno == EWOULDBLOCK { throw SocketError.blocked }
    else if errnoSignalsDisconnected() || count == 0 { throw SocketError.disconnected }
    ...
}
```

So an EOF read whose `errno` was left as `EWOULDBLOCK` by an earlier would-block read **on the same thread** is misclassified as `.blocked` instead of `.disconnected`. The reader then re-suspends waiting for more data instead of closing.

Because `errno` is per-thread, this only manifests under concurrency (a would-block read on one connection contaminating an EOF read on another). The consequences:

- The connection never closes — it lingers in `CLOSE-WAIT` (fd leak).
- `epoll` keeps re-reporting the readable EOF socket, so the pool spins re-arming (`EPOLL_CTL_ADD`/`DEL`) and re-reading it (`read()==0`), pegging CPU.

Reproducible with a handful of concurrent half-closed keep-alive connections (`shutdown(SHUT_WR)`, held open): the server pins a core and accumulates `CLOSE-WAIT` sockets. With the fix, CPU stays at 0 and no sockets leak.

Fix: check `count == 0` first; `errno` is only meaningful after a `-1` return. Applied to `read`, `recvFrom`, and `recvMsg`.