### PR TITLE
make HTTPClient public ~Copyable

### DIFF
--- a/FlyingFox/Sources/HTTPClient.swift
+++ b/FlyingFox/Sources/HTTPClient.swift
@@ -31,19 +31,28 @@
 
 import FlyingSocks
 
-@_spi(Private)
-public struct _HTTPClient {
+@available(*, deprecated, renamed: "HTTPClient")
+public typealias _HTTPClient = HTTPClient
+
+public struct HTTPClient: ~Copyable {
+
+    private var _lastSocket: AsyncSocket?
 
     public init() { }
 
-    public func sendHTTPRequest(_ request: HTTPRequest, to address: some SocketAddress) async throws -> HTTPResponse {
+    public mutating func sendHTTPRequest(_ request: HTTPRequest, to address: some SocketAddress) async throws -> HTTPResponse {
+
+        try? _lastSocket?.close()
+        _lastSocket = nil
+
         let socket = try await AsyncSocket.connected(to: address)
+        _lastSocket = socket
         try await socket.writeRequest(request)
-        let response = try await socket.readResponse()
-        // if streaming very large responses then you shouldn't close here
-        // maybe better to close in deinit instead
-        try? socket.close()
-        return response
+        return try await socket.readResponse()
+    }
+
+    deinit {
+        try? _lastSocket?.close()
     }
 }
 

--- a/FlyingFox/Tests/HTTPClientTests.swift
+++ b/FlyingFox/Tests/HTTPClientTests.swift
@@ -30,7 +30,6 @@
 //
 
 #if canImport(Darwin)
-@_spi(Private) import struct FlyingFox._HTTPClient
 @testable import FlyingFox
 @testable import FlyingSocks
 import Foundation
@@ -44,7 +43,7 @@ struct HTTPClientTests {
         let server = HTTPServer(address: .loopback(port: 0))
         let task = Task { try await server.run() }
         defer { task.cancel() }
-        let client = _HTTPClient()
+        var client = HTTPClient()
 
         // when
         let port = try await server.waitForListeningPort()


### PR DESCRIPTION
Make the private spa `_HTTPClient` public, and `~Copyable` allowing it stream responses closing the socket when done.

resolves #216 