### PR TITLE
Fix heap allocation leak in Socket.getValue

### DIFF
--- a/FlyingSocks/Sources/Socket.swift
+++ b/FlyingSocks/Sources/Socket.swift
@@ -158,6 +158,7 @@ public struct Socket: Sendable, Hashable {
 
     public func getValue<O: SocketOption>(for option: O) throws -> O.Value {
         let valuePtr = UnsafeMutablePointer<O.SocketValue>.allocate(capacity: 1)
+        defer { valuePtr.deallocate() }
         var length = socklen_t(MemoryLayout<O.SocketValue>.size)
         guard Socket.getsockopt(file.rawValue, option.level, option.name, valuePtr, &length) >= 0 else {
             throw SocketError.makeFailed("GetOption")


### PR DESCRIPTION
## Summary

`Socket.getValue` allocates an `UnsafeMutablePointer<O.SocketValue>` that is never deallocated — on either the success or throw path — leaking one heap block on every socket-option read (`socketType`, `receiveBufferSize`, `sendBufferSize`, etc.).

The fix adds `defer { valuePtr.deallocate() }` immediately after allocation. This satisfies the documented precondition of `UnsafeMutablePointer.deallocate()`: the pointer is the start of the allocated block, and the memory is never initialized through Swift's typed model (`getsockopt` writes raw bytes; existing conformances use trivial `Int32` values).

## Testing

Full suite passes (449 tests, 51 suites). Existing `SocketTests` already cover correct value reads through `getValue`; the leak itself is not assertable in unit form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)