### PR TITLE
SocketPool+kQueue: retry kevent on EINTR instead of failing

### DIFF
--- a/FlyingSocks/Sources/SocketPool+kQueue.swift
+++ b/FlyingSocks/Sources/SocketPool+kQueue.swift
@@ -133,6 +133,11 @@ public struct kQueue: EventQueue {
         var events = Array(repeating: kevent(), count: eventsLimit)
         let status = kevent(file.rawValue, nil, 0, &events, Int32(eventsLimit), nil)
         guard status > 0 else {
+            // EINTR (signal) is not a failure: report no events so the caller
+            // polls again rather than tearing down the server. See kevent(2).
+            if status == -1 && errno == EINTR {
+                return []
+            }
             throw SocketError.makeFailed("kqueue kevent")
         }
 


### PR DESCRIPTION
## Summary

Applies the same fix as a196c2e (ePoll) to the kQueue backend. `kevent(2)` documents: *"[EINTR] A signal was delivered before the timeout expired and before any events were placed on the kqueue for return."* No events are lost — but `getNotifications()` treated `-1`/`EINTR` as fatal, unwinding `SocketPool.run()` whose `defer { cancelAll() }` cancels every waiting continuation. A single signal delivery (e.g. Xcode's debugger pausing/resuming the process) tore down the whole pool on Darwin.

Now returns no events so the caller polls again, using the same guard shape and comment as the ePoll fix.

The `Poll` backend has the same gap, but a fix there interacts with Windows/`WSAPoll` semantics — see #228 for details and a proposed direction.

## Testing

Full suite passes (449 tests, 51 suites). No new test: forcing EINTR requires delivering a signal to the exact thread blocked in `kevent`, which isn't deterministically arrangeable under Swift Concurrency (the ePoll fix in a196c2e shipped without a test for the same reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)