### PR TITLE
Darwin: fix sockaddr_un overflow in makeAddressUnix for long paths

### DIFF
--- a/FlyingSocks/Sources/Socket+Darwin.swift
+++ b/FlyingSocks/Sources/Socket+Darwin.swift
@@ -89,12 +89,15 @@ extension Socket {
     static func makeAddressUnix(path: String) -> Darwin.sockaddr_un {
         var addr = Darwin.sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
-        let pathCount = min(path.utf8.count, 104)
+        // Darwin <sys/un.h> declares `char sun_path[104]`; reserve the last byte
+        // for the NUL terminator that String(cString:) and unlink() read back.
+        let pathCount = min(path.utf8.count, 103)
         let len = UInt8(MemoryLayout<UInt8>.size + MemoryLayout<sa_family_t>.size + pathCount + 1)
-        _ = withUnsafeMutablePointer(to: &addr.sun_path.0) { ptr in
+        withUnsafeMutablePointer(to: &addr.sun_path.0) { ptr in
             path.withCString {
-                strncpy(ptr, $0, Int(len))
+                _ = strncpy(ptr, $0, pathCount)
             }
+            ptr[pathCount] = 0
         }
         addr.sun_len = len
         return addr

--- a/FlyingSocks/Tests/SocketAddressTests.swift
+++ b/FlyingSocks/Tests/SocketAddressTests.swift
@@ -148,6 +148,30 @@ struct SocketAddressTests {
         )
     }
 
+    #if canImport(Darwin)
+    @Test
+    func unixMaxLengthPath_IsCorrectlyDecodedFromStorage() throws {
+        let path = "/tmp/" + String(repeating: "x", count: 98)
+        let addr = sockaddr_un.unix(path: path)
+
+        #expect(Int(addr.sun_len) <= MemoryLayout<sockaddr_un>.size)
+        #expect(
+            try Socket.makeAddress(from: addr.makeStorage()) == .unix(path)
+        )
+    }
+
+    @Test
+    func unixOverlongPath_TruncatesWithoutOverflow() throws {
+        let path = "/tmp/" + String(repeating: "x", count: 99)
+        let addr = sockaddr_un.unix(path: path)
+
+        #expect(Int(addr.sun_len) <= MemoryLayout<sockaddr_un>.size)
+        #expect(
+            try Socket.makeAddress(from: addr.makeStorage()) == .unix(String(path.prefix(103)))
+        )
+    }
+    #endif
+
     #if canImport(Glibc) || canImport(Musl) || canImport(Android)
     @Test
     func unixAbstractNamespace_IsCorrectlyDecodedFromStorage() throws {
@@ -268,7 +292,7 @@ struct SocketAddressTests {
     func maximumPathLengthForUnixDomainSocket() {
         var addrUn = sockaddr_un()
         addrUn.sun_family = sa_family_t(AF_UNIX)
-        let maxPathLength = MemoryLayout<sockaddr_un>.size - MemoryLayout<sa_family_t>.size - 1
+        let maxPathLength = MemoryLayout.size(ofValue: addrUn.sun_path) - 1
         let maxPath = String(repeating: "a", count: maxPathLength)
         _ = maxPath.withCString { pathPtr in
             memcpy(&addrUn.sun_path, pathPtr, maxPath.count + 1)


### PR DESCRIPTION
## Summary

- `Socket.makeAddressUnix(path:)` on Darwin clamped the path to 104 bytes but bounded `strncpy` by `sun_len` (up to 106), writing past the end of `sun_path` — which Darwin `<sys/un.h>` declares as `char sun_path[104]`. Paths ≥ 102 bytes overflowed the struct.
- The path is now truncated to 103 bytes and `sun_path` is always NUL-terminated, so `String(cString:)` and `unlink()` read back a valid C string.
- Fixes the same off-by-one in the existing `maximumPathLengthForUnixDomainSocket` test, which computed the capacity from struct arithmetic that omitted `sun_len` and copied 105 bytes into the 104-byte field (caught by AddressSanitizer).

## Test plan

- Added round-trip tests for a max-length (103-byte) path and an overlong path that must truncate without overflow.
- `swift test --filter SocketAddressTests` — 20/20 pass.
- `swift test --sanitize address --filter SocketAddressTests` — clean, no ASan reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)