### PR TITLE
Darwin: correct ipv6_pktinfo to IPV6_3542PKTINFO (46)

### DIFF
--- a/FlyingSocks/Sources/Socket+Darwin.swift
+++ b/FlyingSocks/Sources/Socket+Darwin.swift
@@ -51,8 +51,11 @@ extension Socket {
     static let ipproto_ip = Int32(IPPROTO_IP)
     static let ipproto_ipv6 = Int32(IPPROTO_IPV6)
     static let ip_pktinfo = Int32(IP_PKTINFO)
-    static let ipv6_pktinfo = Int32(50) // __APPLE_USE_RFC_2292
-    static let ipv6_recvpktinfo = Int32(61) // __APPLE_USE_RFC_2292
+    // Swift cannot define __APPLE_USE_RFC_3542 before importing Darwin, so
+    // the RFC 3542 values from <netinet6/in6.h> are hardcoded:
+    // IPV6_PKTINFO = IPV6_3542PKTINFO (46), IPV6_RECVPKTINFO (61).
+    static let ipv6_pktinfo = Int32(46) // __APPLE_USE_RFC_3542
+    static let ipv6_recvpktinfo = Int32(61) // __APPLE_USE_RFC_3542
 
     static func makeAddressINET(port: UInt16) -> Darwin.sockaddr_in {
         Darwin.sockaddr_in(

--- a/FlyingSocks/Tests/AsyncSocketTests.swift
+++ b/FlyingSocks/Tests/AsyncSocketTests.swift
@@ -297,6 +297,33 @@ struct AsyncSocketTests {
         )
     }
     #endif
+
+    @Test
+    func receiveMessage_ParsesIPv6PacketInfo() async throws {
+        // TVT-1131 regression: Socket.ipv6_pktinfo must match the cmsg_type
+        // the kernel delivers for IPV6_RECVPKTINFO — on Darwin the RFC 3542
+        // IPV6_PKTINFO (46), per <netinet6/in6.h>. Datagram sockets enable
+        // pktinfo delivery in Socket.init, so a received Message carries the
+        // parsed interface index and local (destination) address.
+        let (server, port) = try await AsyncSocket.makeLoopbackDatagram()
+
+        async let received: AsyncSocket.Message = server.receive(atMost: 100)
+
+        let client = try await AsyncSocket.makeLoopbackDatagram().0
+        try await client.send(Data("Peas 🫛".utf8), to: sockaddr_in6.loopback(port: port))
+
+        let message = try await received
+        #expect(try message.payloadString == "Peas 🫛")
+        #expect(message.interfaceIndex != nil)
+        let storage = try #require(message.localAddress).makeStorage()
+        let sin6 = withUnsafeBytes(of: storage) { $0.load(as: sockaddr_in6.self) }
+        let loopback = sockaddr_in6.loopback(port: 0).sin6_addr
+        #expect(
+            withUnsafeBytes(of: sin6.sin6_addr) { received in
+                withUnsafeBytes(of: loopback) { received.elementsEqual($0) }
+            }
+        )
+    }
 #endif
 }
 


### PR DESCRIPTION
## Summary

The hardcoded Darwin `ipv6_pktinfo` constant is `50`, which per the macOS SDK `<netinet6/in6.h>` is `IPV6_3542DSTOPTS` (destination-options header) — not pktinfo. The RFC 3542 value paired with the already-used `IPV6_RECVPKTINFO` (61) is `IPV6_3542PKTINFO` (46):

```c
#define IPV6_3542PKTINFO        46 /* in6_pktinfo; send if, src addr */
#define IPV6_3542DSTOPTS        50 /* ip6_dest; send dst option befor rthdr */
#define IPV6_PKTINFO    IPV6_3542PKTINFO   // under __APPLE_USE_RFC_3542
```

Swift cannot define `__APPLE_USE_RFC_3542` before importing Darwin, so these constants must be hardcoded — but with 50, `getPacketInfoControl` never matches the `cmsg_type` the kernel actually delivers (46), and every received IPv6 datagram `Message` carries `interfaceIndex: nil, localAddress: nil` on Darwin.

## Changes

- `Socket+Darwin.swift`: `ipv6_pktinfo` 50 → 46; comments corrected from `__APPLE_USE_RFC_2292` to `__APPLE_USE_RFC_3542` (61 and 46 are RFC 3542 values).
- New test `receiveMessage_ParsesIPv6PacketInfo`: IPv6 loopback datagram round-trip asserting the received `Message` carries the parsed interface index and `::1` local address. Verified to fail with 50 and pass with 46 on macOS.

## Notes

This is a prerequisite for a follow-up fix to the send-side pktinfo control message (its `cmsg_level` is currently `SOL_SOCKET`, which Darwin ignores; once corrected to `IPPROTO_IPV6`, the kernel interprets `cmsg_type` — and with 50 rejects IPv6 sends with `EACCES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)