### PR TITLE
Fall back to internal URL standardization

### DIFF
--- a/FlyingFox/Sources/HTTPDecoder+StandardizePath.swift
+++ b/FlyingFox/Sources/HTTPDecoder+StandardizePath.swift
@@ -42,10 +42,11 @@ extension HTTPDecoder {
         #if canImport(Darwin)
             #if compiler(>=6.2)
             if !fallback, #available(macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *) {
-                return URL(string: path)?.standardized.path
-            } else {
-                return standardizePathDarwinFallback(path)
+                if #unavailable(anyAppleOS 27.0) {
+                    return URL(string: path)?.standardized.path
+                }
             }
+            return standardizePathDarwinFallback(path)
             #else
             return standardizePathDarwinFallback(path)
             #endif

--- a/FlyingFox/Sources/HTTPDecoder+StandardizePath.swift
+++ b/FlyingFox/Sources/HTTPDecoder+StandardizePath.swift
@@ -42,7 +42,7 @@ extension HTTPDecoder {
         #if canImport(Darwin)
             #if compiler(>=6.2)
             if !fallback, #available(macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *) {
-                if #unavailable(anyAppleOS 27.0) {
+                if #unavailable(macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0) {
                     return URL(string: path)?.standardized.path
                 }
             }


### PR DESCRIPTION
The tests failed on Xcode 27 because of a change in URL standardisation behaviour. https://github.com/swiftlang/swift-foundation/pull/1942 changed it. Perhaps the new implementation is more correct, but it is inconsistent with the other implementations in FlyingFox which support other OS versions.

For appleOS 27.0 and above, I have changed it to fall back to the internal URL standardization, which itself was taken from FoundationEssentails before they changed it in the above PR.

AFAICT this is the only failing test on macOS 27.0 (so far…………)

Does it break in macOS 26? Hopefully not.